### PR TITLE
Test for request current before calling is_ajax()

### DIFF
--- a/classes/Ingenerator/View/Layout.php
+++ b/classes/Ingenerator/View/Layout.php
@@ -151,13 +151,16 @@ abstract class Ingenerator_View_Layout extends View_Model
         }
 
         // Guess based on is_ajax
-        if (Request::current()->is_ajax())
+        if (Request::current())
         {
-            return false;
-        }
-        else
-        {
-            return true;
+            if (Request::current()->is_ajax())
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
This can result in a fatal if the request does not match a valid route