### PR TITLE
Use phpunit directly for tests instead of using unittest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /vendor
 /modules
+/.koharness_bootstrap.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_script:
 
 
 # Run the View tests against the koharnessed application in /tmp/koharness
-script: cd /tmp/koharness && phpunit --bootstrap=modules/unittest/bootstrap.php --group=view_model modules/unittest/tests.php
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,11 @@
     "require": {
         "composer/installers": "~1.0",
         "kohana/core":         "3.3.*",
-        "php":                 ">=5.3.3"
+        "php":                 ">=5.3.3",
+        "phpunit/phpunit": "^4.5"
     },
     "require-dev": {
-        "kohana/koharness": "dev-master",
-        "kohana/unittest":  "3.3.*"
+        "kohana/koharness": "dev-master"
     },
     "minimum-stability": "dev"
 }

--- a/koharness.php
+++ b/koharness.php
@@ -9,6 +9,5 @@
 return array(
   'modules' => array(
     'kohana-view' => __DIR__,
-    'unittest'    => __DIR__.'/modules/unittest',
   )
 );

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<!-- Config file for PHPUnit automated tests -->
+<phpunit
+        bootstrap="tests/bootstrap.php"
+        cacheTokens="false"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>tests/unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+# Bootstrap for running unit tests
+error_reporting(E_ALL | E_STRICT);
+define('TEST_ROOT_PATH', realpath(__DIR__).'/');
+require_once(__DIR__.'/../koharness_bootstrap.php');
+require_once(KOHARNESS_SRC.'helper_classes/Session/Fake.php');

--- a/tests/unit/ViewModelTest.php
+++ b/tests/unit/ViewModelTest.php
@@ -4,7 +4,7 @@
  *
  * @group view_model
  */
-class View_Model_Test extends Kohana_Unittest_TestCase
+class View_Model_Test extends PHPUnit_Framework_TestCase
 {
     protected static $old_modules = array();
 
@@ -15,7 +15,7 @@ class View_Model_Test extends Kohana_Unittest_TestCase
     {
         self::$old_modules = Kohana::modules();        
         $new_modules = self::$old_modules+array(
-                'test_views' => realpath(dirname(__FILE__).'/test_data/')
+                'test_views' => TEST_ROOT_PATH.'test_data'
         );                
         Kohana::modules($new_modules);
     }


### PR DESCRIPTION
Simplify the build dependencies - there's nothing we want from kohana/unittest so just get rid of it for the moment and add separate phpunit configuration.
