### PR TITLE
[Breaking] Support default variables in AbstractViewModel classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 3.0.0
+* AbstractViewModel now supports default variables, which can be declared in the view model class,
+  overridden as optional arguments to the display method, and are reinitialised to default for each
+  display call. May be breaking if your child classes define their own `default_variables` property.
+
 ## 2.1.0
 * Made the template directory (within the CFS) configurable - eg to allow templates
   in /templates etc rather than /views.

--- a/README.md
+++ b/README.md
@@ -241,6 +241,41 @@ class Controller_Welcome extends Controller // Look, extend any controller! No m
 Advanced examples
 -----------------
 
+### Default variables
+
+As standard, Views require that the array passed to `AbstractViewModel->display()` contains values for all defined variables.
+This is to ensure that the view model is always in the correct state even if it is rendered multiple times (as often happens
+with partials and sub-views).
+
+You can define optional view variables by populating the `$default_variables` array in your ViewModel. Note that these 
+defaults **will be reassigned** to the `$variables` array on every call to `->display()` to ensure that they are always in
+expected state.
+
+```php
+class View_Something extends AbstractViewModel {
+  protected $default_variables = [
+    'title' => 'My page title',
+  ];
+
+  protected $variables = [
+    'caption' => NULL
+  ];
+
+}
+
+print $view->title;    // 'My page title'
+print $view->caption;  // ''
+
+$view->display(['caption' => 'Something', 'title' => 'A title']);
+print $view->title;    // 'A title'
+print $view->caption;  // 'Something'
+
+$view->display(['caption' => 'Something else']);
+print $view->title;    // 'My page title'
+print $view->caption;  // 'Something else'
+
+```
+
 ### Caching variables
 
 Views that extend `AbstractViewModel` expose all the variables in their `$variables` array and also any dynamic

--- a/classes/Ingenerator/KohanaView/ViewModel/AbstractViewModel.php
+++ b/classes/Ingenerator/KohanaView/ViewModel/AbstractViewModel.php
@@ -40,6 +40,12 @@ use Ingenerator\KohanaView\ViewModel;
  */
 abstract class AbstractViewModel implements ViewModel
 {
+
+    /**
+     * @var array Variables that will be set back to defaults on each display unless a new value is passed
+     */
+    protected $default_variables = [];
+
     /**
      * @var array The actual view data
      */
@@ -52,6 +58,8 @@ abstract class AbstractViewModel implements ViewModel
 
     public function __construct()
     {
+        $this->variables = array_merge($this->default_variables, $this->variables);
+
         // Assign the expect_var_names to ensure that we don't accidentally start requiring compiled fields
         $this->expect_var_names = array_keys($this->variables);
     }
@@ -94,6 +102,9 @@ abstract class AbstractViewModel implements ViewModel
      */
     public function display(array $variables)
     {
+        // Reinstate default variables to ensure they are in expected state when using view in a loop
+        $variables = array_merge($this->default_variables, $variables);
+
         if ($errors = $this->validateDisplayVariables($variables)) {
             throw InvalidDisplayVariablesException::passedToDisplay(static::class, $errors);
         }

--- a/tests/unit/Ingenerator/KohanaView/ViewModel/AbstractViewModelTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewModel/AbstractViewModelTest.php
@@ -24,6 +24,11 @@ class AbstractViewModelTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('expected value', $this->newSubject()->some_defined_var);
     }
 
+    public function test_it_provides_magic_read_access_to_defined_default_variables()
+    {
+        $this->assertEquals('default value', $this->newSubject()->some_defaulted_var);
+    }
+
     public function test_it_provides_magic_read_access_to_protected_var_methods()
     {
         $this->assertEquals('expected dynamic', $this->newSubject()->some_dynamic_var);
@@ -45,6 +50,7 @@ class AbstractViewModelTest extends \PHPUnit_Framework_TestCase
         /** @noinspection PhpUndefinedFieldInspection */
         $this->newSubject()->some_undefined_var;
     }
+
 
     /**
      * @expectedException \Ingenerator\KohanaView\Exception\InvalidViewVarAssignmentException
@@ -91,6 +97,33 @@ class AbstractViewModelTest extends \PHPUnit_Framework_TestCase
         $this->newSubject()->display([]);
     }
 
+    public function test_its_display_method_can_override_default_values()
+    {
+        $subject = $this->newSubject();
+        $subject->display(
+            [
+                'some_defined_var'   => 'required',
+                'some_defaulted_var' => 'custom',
+            ]
+        );
+        $this->assertSame('custom', $subject->some_defaulted_var);
+    }
+
+    public function test_its_display_method_reinitialises_default_values_if_not_present()
+    {
+        $subject = $this->newSubject();
+        $subject->display(
+            [
+                'some_defined_var'   => 'required',
+                'some_defaulted_var' => 'custom',
+            ]
+        );
+
+        $subject->display(['some_defined_var' => 'custom2']);
+        $this->assertSame('custom2', $subject->some_defined_var);
+        $this->assertSame('default value', $subject->some_defaulted_var);
+    }
+
     /**
      * @expectedException \Ingenerator\KohanaView\Exception\InvalidDisplayVariablesException
      * @expectedExceptionMessage 'some_dynamic_var' conflicts with ::var_some_dynamic_var()
@@ -127,6 +160,10 @@ class AbstractViewModelTest extends \PHPUnit_Framework_TestCase
  */
 class TestViewModel extends AbstractViewModel
 {
+
+    protected $default_variables = [
+        'some_defaulted_var' => 'default value',
+    ];
 
     protected $variables = [
         'some_defined_var' => 'expected value',


### PR DESCRIPTION
Allows initalisation of variables that can optionally be overridden
in the `display` call but otherwise will have default values that
are reinitialised for each display call.
