### PR TITLE
Fix phpunit to be a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,11 @@
     "require": {
         "composer/installers": "~1.0",
         "kohana/core":         "3.3.*",
-        "php":                 ">=5.3.3",
-        "phpunit/phpunit": "^4.5"
+        "php":                 ">=5.3.3"
     },
     "require-dev": {
-        "kohana/koharness": "dev-master"
+        "kohana/koharness": "dev-master",
+        "phpunit/phpunit": "^4.5"
     },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
In #7 it was accidentally added as prod, causing a dependency
conflict downstream