### PR TITLE
refactor: Add rector and initial rule sets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,3 +65,21 @@ jobs:
 
       - name: Run PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix --dry-run --verbose --diff
+
+  rector:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          ini-values: "zend.exception_ignore_args=Off"
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update
+
+      - name: Run Rector
+        run: ./vendor/bin/rector --dry-run

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,13 +1,16 @@
 <?php
 
 
+use PhpCsFixer\Finder;
+use PhpCsFixer\Config;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
 
-$finder = (new PhpCsFixer\Finder())
+$finder = (new Finder())
     ->in(__DIR__);
 
-return (new PhpCsFixer\Config())
-    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules([
         // @todo: Bump to php84 migration when we drop 8.2 support

--- a/classes/Ingenerator/KohanaView/Exception/UnspecifiedTemplateNameException.php
+++ b/classes/Ingenerator/KohanaView/Exception/UnspecifiedTemplateNameException.php
@@ -4,8 +4,6 @@ namespace Ingenerator\KohanaView\Exception;
 
 use UnexpectedValueException;
 
-use function gettype;
-use function is_object;
 use function sprintf;
 
 /**
@@ -37,7 +35,7 @@ class UnspecifiedTemplateNameException extends UnexpectedValueException
             sprintf(
                 '%s::getTemplateName() must return a string template name, %s value returned',
                 $view_class,
-                is_object($template) ? $template::class : gettype($template)
+                get_debug_type($template)
             )
         );
     }

--- a/classes/Ingenerator/KohanaView/Renderer/PageLayoutRenderer.php
+++ b/classes/Ingenerator/KohanaView/Renderer/PageLayoutRenderer.php
@@ -76,9 +76,9 @@ class PageLayoutRenderer
 
         if ($parent instanceof NestedChildView) {
             return $this->render($parent);
-        } else {
-            return $this->view_renderer->render($parent);
         }
+
+        return $this->view_renderer->render($parent);
     }
 
     /**
@@ -90,11 +90,7 @@ class PageLayoutRenderer
             return $this->use_layout;
         }
 
-        if ($this->current_request && $this->current_request->is_ajax()) {
-            return false;
-        } else {
-            return true;
-        }
+        return ! ($this->current_request && $this->current_request->is_ajax());
     }
 
     /**

--- a/classes/Ingenerator/KohanaView/TemplateCompiler.php
+++ b/classes/Ingenerator/KohanaView/TemplateCompiler.php
@@ -9,7 +9,6 @@ use function array_merge;
 use function preg_match;
 use function preg_replace_callback;
 use function strlen;
-use function strncmp;
 use function substr;
 use function trim;
 
@@ -113,6 +112,6 @@ class TemplateCompiler
      */
     protected function startsWith($string, $prefix)
     {
-        return strncmp($string, $prefix, strlen($prefix)) === 0;
+        return str_starts_with($string, $prefix);
     }
 }

--- a/classes/Ingenerator/KohanaView/TemplateManager/CFSTemplateManager.php
+++ b/classes/Ingenerator/KohanaView/TemplateManager/CFSTemplateManager.php
@@ -67,7 +67,7 @@ class CFSTemplateManager implements TemplateManager
     {
         $this->cascading_files = $cascading_files ?: new CFSWrapper();
         $this->compiler = $compiler;
-        $this->cache_dir = rtrim($options['cache_dir'], '/');
+        $this->cache_dir = rtrim((string) $options['cache_dir'], '/');
         $this->recompile_always = Arr::get($options, 'recompile_always', false);
         $this->template_dir = rtrim(Arr::get($options, 'template_dir', 'views'), '/');
     }

--- a/classes/Ingenerator/KohanaView/TemplateManager/CFSTemplateManager.php
+++ b/classes/Ingenerator/KohanaView/TemplateManager/CFSTemplateManager.php
@@ -131,7 +131,7 @@ class CFSTemplateManager implements TemplateManager
     {
         try {
             Kohana::ensureDirectory($path, 0o777);
-        } catch (Kohana_Exception $e) {
+        } catch (Kohana_Exception) {
             throw TemplateCacheException::cannotCreateDirectory($path);
         }
 

--- a/classes/Ingenerator/KohanaView/ViewModel/AbstractViewModel.php
+++ b/classes/Ingenerator/KohanaView/ViewModel/AbstractViewModel.php
@@ -75,13 +75,15 @@ abstract class AbstractViewModel implements ViewModel
     {
         if (array_key_exists($name, $this->variables)) {
             return $this->variables[$name];
-        } elseif (method_exists($this, 'var_'.$name)) {
+        }
+        if (method_exists($this, 'var_'.$name)) {
             $method = 'var_'.$name;
 
             return $this->$method();
-        } else {
-            throw UndefinedViewVarException::forClassAndVar(static::class, $name);
         }
+        throw UndefinedViewVarException::forClassAndVar(static::class, $name);
+
+        return null;
     }
 
     /**

--- a/classes/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageLayoutView.php
+++ b/classes/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageLayoutView.php
@@ -2,8 +2,9 @@
 
 namespace Ingenerator\KohanaView\ViewModel\PageLayout;
 
-use Ingenerator\KohanaView\ViewModel;
 use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+use Ingenerator\KohanaView\ViewModel\NestedParentView;
+use Ingenerator\KohanaView\ViewModel\PageLayoutView;
 
 /**
  * Provides a base class for all views that are intended to provide a complete HTML template that will
@@ -15,7 +16,7 @@ use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
  * @property-read string $body_html The content to display in the body HTML area
  * @property-read string $title The page title
  */
-abstract class AbstractPageLayoutView extends AbstractViewModel implements ViewModel\PageLayoutView, ViewModel\NestedParentView
+abstract class AbstractPageLayoutView extends AbstractViewModel implements PageLayoutView, NestedParentView
 {
     /**
      * @var array

--- a/classes/Ingenerator/KohanaView/ViewTemplateSelector.php
+++ b/classes/Ingenerator/KohanaView/ViewTemplateSelector.php
@@ -30,9 +30,9 @@ class ViewTemplateSelector
     {
         if ($view instanceof TemplateSpecifyingViewModel) {
             return $this->validateSpecifiedTemplateName($view);
-        } else {
-            return $this->calculateTemplateFromClassName($view);
         }
+
+        return $this->calculateTemplateFromClassName($view);
     }
 
     /**

--- a/classes/Ingenerator/KohanaView/ViewTemplateSelector.php
+++ b/classes/Ingenerator/KohanaView/ViewTemplateSelector.php
@@ -62,9 +62,9 @@ class ViewTemplateSelector
     {
         $template = $view::class;
         $template = preg_replace('/\\\\|_/', '/', $template);
-        $template = preg_replace('#(^view/?(model)?/)|(?<!/)(view/?(model)?$)#i', '', $template);
-        $template = preg_replace('/([a-z])([A-Z])/', '\1_\2', $template);
-        $template = strtolower($template);
+        $template = preg_replace('#(^view/?(model)?/)|(?<!/)(view/?(model)?$)#i', '', (string) $template);
+        $template = preg_replace('/([a-z])([A-Z])/', '\1_\2', (string) $template);
+        $template = strtolower((string) $template);
 
         return $template;
     }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "mikey179/vfsstream": "^1.6.12",
         "ingenerator/kohana-dependencies": "^1.3.0",
         "phpunit/phpunit": "^9.6.23",
-        "friendsofphp/php-cs-fixer": "^3.88"
+        "friendsofphp/php-cs-fixer": "^3.88",
+        "rector/rector": "^2.1"
     },
     "suggest": {
         "ingenerator/kohana-dependencies": "Dependency Injection container for Kohana 3.x"

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -1,6 +1,10 @@
 <?php
 
+use Ingenerator\KohanaView\Renderer\HTMLRenderer;
 use Ingenerator\KohanaView\Renderer\PageLayoutRenderer;
+use Ingenerator\KohanaView\TemplateCompiler;
+use Ingenerator\KohanaView\TemplateManager\CFSTemplateManager;
+use Ingenerator\KohanaView\ViewTemplateSelector;
 
 /*
  * KohanaView dependency container configuration for use with https://github.com/zeelot/kohana-dependencies.
@@ -10,7 +14,7 @@ return [
         'renderer' => [
             'html' => [
                 '_settings' => [
-                    'class' => '\Ingenerator\KohanaView\Renderer\HTMLRenderer',
+                    'class' => HTMLRenderer::class,
                     'arguments' => ['%kohanaview.template.selector%', '%kohanaview.template.manager%'],
                     'shared' => true,
                 ],
@@ -26,21 +30,21 @@ return [
         'template' => [
             'compiler' => [
                 '_settings' => [
-                    'class' => '\Ingenerator\KohanaView\TemplateCompiler',
+                    'class' => TemplateCompiler::class,
                     'arguments' => [],
                     'shared' => true,
                 ],
             ],
             'manager' => [
                 '_settings' => [
-                    'class' => '\Ingenerator\KohanaView\TemplateManager\CFSTemplateManager',
+                    'class' => CFSTemplateManager::class,
                     'arguments' => ['%kohanaview.template.compiler%', '@kohanaview.template_manager@'],
                     'shared' => true,
                 ],
             ],
             'selector' => [
                 '_settings' => [
-                    'class' => '\Ingenerator\KohanaView\ViewTemplateSelector',
+                    'class' => ViewTemplateSelector::class,
                     'arguments' => [],
                     'shared' => true,
                 ],

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -1,6 +1,8 @@
 <?php
 
-/**
+use Ingenerator\KohanaView\Renderer\PageLayoutRenderer;
+
+/*
  * KohanaView dependency container configuration for use with https://github.com/zeelot/kohana-dependencies.
  */
 return [
@@ -15,7 +17,7 @@ return [
             ],
             'page_layout' => [
                 '_settings' => [
-                    'class' => Ingenerator\KohanaView\Renderer\PageLayoutRenderer::class,
+                    'class' => PageLayoutRenderer::class,
                     'arguments' => ['%kohanaview.renderer.html%', '%kohana.request%'],
                     'shared' => true,
                 ],

--- a/rector.php
+++ b/rector.php
@@ -11,7 +11,7 @@ return RectorConfig::configure()
         __DIR__.'/tests',
     ])
     ->withRootFiles()
-    ->withCodeQualityLevel(0)
+    ->withCodeQualityLevel(100)
     ->withImportNames(
         removeUnusedImports: true,
     );

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -19,9 +20,9 @@ return RectorConfig::configure()
         ClassConstantToSelfClassRector::class,
         StringClassNameToClassConstantRector::class,
         //        \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
-        //        \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
-        //        \Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector::class,
-        //        \Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector::class,
+        // ClosureToArrowFunctionRector::class,
+        // ReturnNeverTypeRector::class,
+        RemoveUnusedVariableInCatchRector::class,
         //        \Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
         //        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
     ])

--- a/rector.php
+++ b/rector.php
@@ -15,6 +15,7 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(
         codeQuality: true,
+        earlyReturn: true,
     )
     ->withPhpSets()
     ->withSkip([

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/classes',
+        __DIR__.'/config',
+        __DIR__.'/tests',
+    ])
+    ->withRootFiles()
+    ->withCodeQualityLevel(0)
+    ->withImportNames(
+        removeUnusedImports: true,
+    );

--- a/rector.php
+++ b/rector.php
@@ -2,13 +2,9 @@
 
 declare(strict_types=1);
 
-use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
-use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
-use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -18,16 +14,16 @@ return RectorConfig::configure()
     ])
     ->withRootFiles()
     ->withCodeQualityLevel(100)
-//    ->withPhpSets()
-    ->withRules([
-        ClassConstantToSelfClassRector::class,
-        StringClassNameToClassConstantRector::class,
-        ClassPropertyAssignToConstructorPromotionRector::class,
-        // ClosureToArrowFunctionRector::class,
-        // ReturnNeverTypeRector::class,
-        RemoveUnusedVariableInCatchRector::class,
-        NullToStrictStringFuncCallArgRector::class,
-                ReadOnlyPropertyRector::class,
+    ->withPhpSets()
+    ->withSkip([
+        ClosureToArrowFunctionRector::class => [
+            // Needs to be a traditional function in order to restrict the scope
+            __DIR__.'/classes/Ingenerator/KohanaView/Renderer/HTMLRenderer.php',
+        ],
+        ReturnNeverTypeRector::class => [
+            // This stub function shouldn't return `never` as it will actually "return" a string
+            __DIR__.'/classes/raw_fn_stub.php',
+        ],
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -23,7 +24,7 @@ return RectorConfig::configure()
         // ClosureToArrowFunctionRector::class,
         // ReturnNeverTypeRector::class,
         RemoveUnusedVariableInCatchRector::class,
-        //        \Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
+        NullToStrictStringFuncCallArgRector::class,
         //        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
     ])
     ->withImportNames(

--- a/rector.php
+++ b/rector.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -16,13 +17,13 @@ return RectorConfig::configure()
 //    ->withPhpSets()
     ->withRules([
         ClassConstantToSelfClassRector::class,
-//        \Rector\Php55\Rector\String_\StringClassNameToClassConstantRector::class,
-//        \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
-//        \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
-//        \Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector::class,
-//        \Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector::class,
-//        \Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
-//        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
+        StringClassNameToClassConstantRector::class,
+        //        \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
+        //        \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
+        //        \Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector::class,
+        //        \Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector::class,
+        //        \Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
+        //        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/rector.php
+++ b/rector.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 
 return RectorConfig::configure()
@@ -20,12 +22,12 @@ return RectorConfig::configure()
     ->withRules([
         ClassConstantToSelfClassRector::class,
         StringClassNameToClassConstantRector::class,
-        //        \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
+        ClassPropertyAssignToConstructorPromotionRector::class,
         // ClosureToArrowFunctionRector::class,
         // ReturnNeverTypeRector::class,
         RemoveUnusedVariableInCatchRector::class,
         NullToStrictStringFuncCallArgRector::class,
-        //        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
+                ReadOnlyPropertyRector::class,
     ])
     ->withImportNames(
         removeUnusedImports: true,

--- a/rector.php
+++ b/rector.php
@@ -13,7 +13,9 @@ return RectorConfig::configure()
         __DIR__.'/tests',
     ])
     ->withRootFiles()
-    ->withCodeQualityLevel(100)
+    ->withPreparedSets(
+        codeQuality: true,
+    )
     ->withPhpSets()
     ->withSkip([
         ClosureToArrowFunctionRector::class => [

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
@@ -12,6 +13,17 @@ return RectorConfig::configure()
     ])
     ->withRootFiles()
     ->withCodeQualityLevel(100)
+//    ->withPhpSets()
+    ->withRules([
+        ClassConstantToSelfClassRector::class,
+//        \Rector\Php55\Rector\String_\StringClassNameToClassConstantRector::class,
+//        \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
+//        \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
+//        \Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector::class,
+//        \Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector::class,
+//        \Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
+//        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
+    ])
     ->withImportNames(
         removeUnusedImports: true,
     );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,12 +1,14 @@
 <?php
 
+use Composer\Autoload\ClassLoader;
+
 // Bootstrap for running unit tests
 define('TEST_ROOT_PATH', realpath(__DIR__).'/');
 require_once __DIR__.'/../koharness_bootstrap.php';
 require_once KOHARNESS_SRC.'helper_classes/Session/Fake.php';
 
 // Autoload mocks and test-support helpers that should not autoload in the main app
-$mock_loader = new Composer\Autoload\ClassLoader();
+$mock_loader = new ClassLoader();
 $mock_loader->addPsr4('test\\mock\\', [__DIR__.'/mock/']);
 $mock_loader->addPsr4('test\\unit\\', [__DIR__.'/unit/']);
 $mock_loader->register();

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -8,6 +8,10 @@ use Ingenerator\KohanaView\Renderer\HTMLRenderer;
 use Ingenerator\KohanaView\TemplateManager\CFSTemplateManager;
 use Ingenerator\KohanaView\ViewModel;
 use Kohana;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use View\Test\CustomView;
+use View\Test\SomeModel;
 
 use function constant;
 use function dirname;
@@ -25,7 +29,7 @@ use function uniqid;
  *
  * @preserveGlobalState disabled
  */
-class ViewModelIntegrationTest extends \PHPUnit\Framework\TestCase
+class ViewModelIntegrationTest extends TestCase
 {
     public const STALE_COMPILED_STRING = 'Stale content from previous compile';
 
@@ -113,7 +117,7 @@ class ViewModelIntegrationTest extends \PHPUnit\Framework\TestCase
         /** @noinspection PhpUndefinedNamespaceInspection */
         /** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
         /** @noinspection PhpUndefinedClassInspection */
-        $view = new \View\Test\SomeModel();
+        $view = new SomeModel();
         /** @var ViewModel $view */
         $result = $this->getHTMLRenderer($dependencies)->render($view);
 
@@ -150,7 +154,7 @@ class ViewModelIntegrationTest extends \PHPUnit\Framework\TestCase
         /** @noinspection PhpUndefinedNamespaceInspection */
         /** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
         /** @noinspection PhpUndefinedClassInspection */
-        $view = new \View\Test\CustomView();
+        $view = new CustomView();
         /** @var ViewModel $view */
         $this->assertSame(
             'View with &lt;p&gt;Stuff&amp;Things&lt;/p&gt;, <p>Stuff&Things</p>',
@@ -160,8 +164,8 @@ class ViewModelIntegrationTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        \PHPUnit\Framework\Assert::assertTrue($this->isInIsolation(), 'Integration tests must runInSeparateProcess');
-        \PHPUnit\Framework\Assert::assertTrue($this->preserveGlobalState, 'Integration tests must run without globals');
+        Assert::assertTrue($this->isInIsolation(), 'Integration tests must runInSeparateProcess');
+        Assert::assertTrue($this->preserveGlobalState, 'Integration tests must run without globals');
         $this->expectOutputRegex('/^$/');
 
         $this->tmp_dir = sys_get_temp_dir().'/kohana-view-integration/'.uniqid('test');

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -39,7 +39,7 @@ class ViewModelIntegrationTest extends TestCase
     {
         $dependencies = $this->givenDependenciesBootstrapped();
         $renderer = $dependencies->get('kohanaview.renderer.html');
-        $this->assertInstanceOf('Ingenerator\KohanaView\Renderer\HTMLRenderer', $renderer);
+        $this->assertInstanceOf(HTMLRenderer::class, $renderer);
         $this->assertSame($renderer, $dependencies->get('kohanaview.renderer.html'));
     }
 

--- a/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
+++ b/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
@@ -23,8 +23,8 @@ class SingleDirectoryCFSWrapperMock extends CFSWrapper
         $path = $this->root_path.'/'.$dir.'/'.$file.EXT;
         if (file_exists($path)) {
             return $path;
-        } else {
-            return false;
         }
+
+        return false;
     }
 }

--- a/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
+++ b/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
@@ -11,14 +11,11 @@ use function file_exists;
  */
 class SingleDirectoryCFSWrapperMock extends CFSWrapper
 {
-    protected $root_path;
-
     /**
      * @param string $root_path
      */
-    public function __construct($root_path)
+    public function __construct(protected $root_path)
     {
-        $this->root_path = $root_path;
     }
 
     public function find_file($dir, $file)

--- a/tests/mock/ViewModel/FixedTemplateViewModelStub.php
+++ b/tests/mock/ViewModel/FixedTemplateViewModelStub.php
@@ -6,11 +6,8 @@ use Ingenerator\KohanaView\TemplateSpecifyingViewModel;
 
 class FixedTemplateViewModelStub extends ViewModelDummy implements TemplateSpecifyingViewModel
 {
-    private $template;
-
-    public function __construct($template)
+    public function __construct(private $template)
     {
-        $this->template = $template;
     }
 
     /**

--- a/tests/mock/ViewModel/PageLayout/DummyIntermediateLayoutView.php
+++ b/tests/mock/ViewModel/PageLayout/DummyIntermediateLayoutView.php
@@ -3,11 +3,12 @@
 namespace test\mock\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractIntermediateLayoutView;
+use Ingenerator\KohanaView\ViewModel\PageLayoutView;
 
 class DummyIntermediateLayoutView extends AbstractIntermediateLayoutView
 {
     /**
-     * @return \Ingenerator\KohanaView\ViewModel\PageLayoutView
+     * @return PageLayoutView
      */
     public function getUltimatePageView()
     {

--- a/tests/mock/ViewModel/PageLayout/DummyNestedChildView.php
+++ b/tests/mock/ViewModel/PageLayout/DummyNestedChildView.php
@@ -3,11 +3,12 @@
 namespace test\mock\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractNestedChildView;
+use Ingenerator\KohanaView\ViewModel\PageLayoutView;
 
 class DummyNestedChildView extends AbstractNestedChildView
 {
     /**
-     * @return \Ingenerator\KohanaView\ViewModel\PageLayoutView
+     * @return PageLayoutView
      */
     public function getUltimatePageView()
     {

--- a/tests/mock/ViewModel/ViewModelDummy.php
+++ b/tests/mock/ViewModel/ViewModelDummy.php
@@ -34,7 +34,7 @@ class ViewModelDummy implements ViewModel
         $namespace = trim(substr($class_name, 0, -strlen($simple_class)), '\\');
         $definition = sprintf(
             '%s class %s extends %s {}',
-            $namespace ? "namespace $namespace;" : '',
+            $namespace !== '' ? "namespace $namespace;" : '',
             $simple_class,
             '\\'.__CLASS__
         );

--- a/tests/mock/ViewModel/ViewModelDummy.php
+++ b/tests/mock/ViewModel/ViewModelDummy.php
@@ -25,7 +25,7 @@ class ViewModelDummy implements ViewModel
     {
         if (class_exists($class_name)) {
             $instance = new $class_name();
-            Assert::assertInstanceOf(__CLASS__, $instance);
+            Assert::assertInstanceOf(self::class, $instance);
 
             return $instance;
         }
@@ -36,7 +36,7 @@ class ViewModelDummy implements ViewModel
             '%s class %s extends %s {}',
             $namespace !== '' ? "namespace $namespace;" : '',
             $simple_class,
-            '\\'.__CLASS__
+            '\\'.self::class
         );
         eval($definition);
 

--- a/tests/mock/ViewModel/ViewModelDummy.php
+++ b/tests/mock/ViewModel/ViewModelDummy.php
@@ -3,6 +3,7 @@
 namespace test\mock\ViewModel;
 
 use Ingenerator\KohanaView\ViewModel;
+use PHPUnit\Framework\Assert;
 
 use function class_exists;
 use function sprintf;
@@ -24,7 +25,7 @@ class ViewModelDummy implements ViewModel
     {
         if (class_exists($class_name)) {
             $instance = new $class_name();
-            \PHPUnit\Framework\Assert::assertInstanceOf(__CLASS__, $instance);
+            Assert::assertInstanceOf(__CLASS__, $instance);
 
             return $instance;
         }

--- a/tests/unit/Ingenerator/KohanaView/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Ingenerator/KohanaView/Renderer/HTMLRendererTest.php
@@ -8,11 +8,13 @@ use Ingenerator\KohanaView\Renderer;
 use Ingenerator\KohanaView\Renderer\HTMLRenderer;
 use Ingenerator\KohanaView\TemplateManager;
 use Ingenerator\KohanaView\ViewModel;
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
 use Ingenerator\KohanaView\ViewTemplateSelector;
 use InvalidArgumentException;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\ViewModelDummy;
 
@@ -220,7 +222,7 @@ class ViewTemplateSelectorSpy extends ViewTemplateSelector
 
     public function assertCalledOnceWith(ViewModel $view)
     {
-        \PHPUnit\Framework\Assert::assertSame([$view], $this->calls);
+        Assert::assertSame([$view], $this->calls);
     }
 }
 
@@ -243,11 +245,11 @@ class TemplateManagerSpy implements TemplateManager
 
     public function assertCalledOnceWith($template_name)
     {
-        \PHPUnit\Framework\Assert::assertSame([$template_name], $this->calls);
+        Assert::assertSame([$template_name], $this->calls);
     }
 }
 
-class NumberViewModel extends ViewModel\AbstractViewModel
+class NumberViewModel extends AbstractViewModel
 {
     protected $variables = [
         'number' => 0,

--- a/tests/unit/Ingenerator/KohanaView/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Ingenerator/KohanaView/Renderer/PageLayoutRendererTest.php
@@ -8,6 +8,7 @@ use Ingenerator\KohanaView\ViewModel;
 use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\KohanaView\ViewModel\PageLayoutView;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
 use Request;
 use test\mock\ViewModel\PageLayout\DummyIntermediateLayoutView;
 use test\mock\ViewModel\PageLayout\DummyNestedChildView;
@@ -17,7 +18,7 @@ use UnexpectedValueException;
 
 use function spl_object_hash;
 
-class PageLayoutRendererTest extends \PHPUnit\Framework\TestCase
+class PageLayoutRendererTest extends TestCase
 {
     /**
      * @var SimpleRendererStub

--- a/tests/unit/Ingenerator/KohanaView/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Ingenerator/KohanaView/Renderer/PageLayoutRendererTest.php
@@ -218,11 +218,8 @@ class SimpleRendererStub implements Renderer
 
 class IsAjaxRequestStub extends Request
 {
-    private bool $is_ajax;
-
-    public function __construct(bool $is_ajax)
+    public function __construct(private readonly bool $is_ajax)
     {
-        $this->is_ajax = $is_ajax;
     }
 
     public function is_ajax(): bool

--- a/tests/unit/Ingenerator/KohanaView/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Ingenerator/KohanaView/Renderer/PageLayoutRendererTest.php
@@ -33,7 +33,7 @@ class PageLayoutRendererTest extends TestCase
     public function test_it_is_initialisable()
     {
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\Renderer\PageLayoutRenderer',
+            PageLayoutRenderer::class,
             $this->newSubject()
         );
     }

--- a/tests/unit/Ingenerator/KohanaView/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Ingenerator/KohanaView/Renderer/PageLayoutRendererTest.php
@@ -203,12 +203,15 @@ class SimpleRendererStub implements Renderer
         $id_letter = $this->expected_views[$hash];
         if ($view instanceof DummyPageContentView) {
             return "<Content#$id_letter/>";
-        } elseif ($view instanceof DummyPageLayoutView) {
+        }
+        if ($view instanceof DummyPageLayoutView) {
             /* @noinspection PhpUndefinedFieldInspection */
             return "<Layout#$id_letter>\n".$view->body_html."\n</Layout#$id_letter>";
-        } elseif ($view instanceof DummyNestedChildView) {
+        }
+        if ($view instanceof DummyNestedChildView) {
             return "<Child#$id_letter/>";
-        } elseif ($view instanceof DummyIntermediateLayoutView) {
+        }
+        if ($view instanceof DummyIntermediateLayoutView) {
             return "<Intermediate#$id_letter>\n".$view->child_html."\n</Intermediate#$id_letter>";
         }
 

--- a/tests/unit/Ingenerator/KohanaView/TemplateCompilerTest.php
+++ b/tests/unit/Ingenerator/KohanaView/TemplateCompilerTest.php
@@ -4,8 +4,9 @@ namespace test\unit\Ingenerator\KohanaView;
 
 use Ingenerator\KohanaView\Exception\InvalidTemplateContentException;
 use Ingenerator\KohanaView\TemplateCompiler;
+use PHPUnit\Framework\TestCase;
 
-class TemplateCompilerTest extends \PHPUnit\Framework\TestCase
+class TemplateCompilerTest extends TestCase
 {
     protected $options = [];
 

--- a/tests/unit/Ingenerator/KohanaView/TemplateCompilerTest.php
+++ b/tests/unit/Ingenerator/KohanaView/TemplateCompilerTest.php
@@ -13,7 +13,7 @@ class TemplateCompilerTest extends TestCase
     public function test_it_is_initialisable()
     {
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\TemplateCompiler',
+            TemplateCompiler::class,
             $this->newSubject()
         );
     }

--- a/tests/unit/Ingenerator/KohanaView/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/Ingenerator/KohanaView/TemplateManager/CFSTemplateManagerTest.php
@@ -8,6 +8,8 @@ use Ingenerator\KohanaView\TemplateCompiler;
 use Ingenerator\KohanaView\TemplateManager\CFSTemplateManager;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
 use test\mock\CFSWrapper\SingleDirectoryCFSWrapperMock;
 
 use function chmod;
@@ -17,7 +19,7 @@ use function file_put_contents;
 use function is_dir;
 use function mkdir;
 
-class CFSTemplateManagerTest extends \PHPUnit\Framework\TestCase
+class CFSTemplateManagerTest extends TestCase
 {
     protected $options = [];
 
@@ -200,11 +202,11 @@ class SpyingTemplateCompiler extends TemplateCompiler
 
     public function assertCompiledOnce($string)
     {
-        \PHPUnit\Framework\Assert::assertEquals([$string], $this->compiled);
+        Assert::assertEquals([$string], $this->compiled);
     }
 
     public function assertNothingCompiled()
     {
-        \PHPUnit\Framework\Assert::assertEmpty($this->compiled);
+        Assert::assertEmpty($this->compiled);
     }
 }

--- a/tests/unit/Ingenerator/KohanaView/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/Ingenerator/KohanaView/TemplateManager/CFSTemplateManagerTest.php
@@ -5,6 +5,7 @@ namespace test\unit\Ingenerator\KohanaView\TemplateManager;
 use Ingenerator\KohanaView\Exception\TemplateCacheException;
 use Ingenerator\KohanaView\Exception\TemplateNotFoundException;
 use Ingenerator\KohanaView\TemplateCompiler;
+use Ingenerator\KohanaView\TemplateManager;
 use Ingenerator\KohanaView\TemplateManager\CFSTemplateManager;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
@@ -42,11 +43,11 @@ class CFSTemplateManagerTest extends TestCase
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\TemplateManager\CFSTemplateManager',
+            CFSTemplateManager::class,
             $subject
         );
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\TemplateManager',
+            TemplateManager::class,
             $subject
         );
     }

--- a/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageContentViewTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageContentViewTest.php
@@ -3,9 +3,10 @@
 namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageContentView;
+use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
 
-class AbstractPageContentViewTest extends \PHPUnit\Framework\TestCase
+class AbstractPageContentViewTest extends TestCase
 {
     protected $page_layout;
 

--- a/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageContentViewTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageContentViewTest.php
@@ -2,6 +2,8 @@
 
 namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
 
+use Ingenerator\KohanaView\ViewModel;
+use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageContentView;
 use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
@@ -14,15 +16,15 @@ class AbstractPageContentViewTest extends TestCase
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageContentView',
+            AbstractPageContentView::class,
             $subject
         );
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\ViewModel\PageContentView',
+            PageContentView::class,
             $subject
         );
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\ViewModel',
+            ViewModel::class,
             $subject
         );
     }

--- a/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
@@ -4,6 +4,7 @@ namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel;
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageLayoutView;
+use Ingenerator\KohanaView\ViewModel\PageLayoutView;
 use PHPUnit\Framework\TestCase;
 
 class AbstractPageLayoutViewTest extends TestCase
@@ -17,15 +18,15 @@ class AbstractPageLayoutViewTest extends TestCase
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageLayoutView',
+            AbstractPageLayoutView::class,
             $subject
         );
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\ViewModel\PageLayoutView',
+            PageLayoutView::class,
             $subject
         );
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\ViewModel',
+            ViewModel::class,
             $subject
         );
     }

--- a/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
@@ -4,8 +4,9 @@ namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel;
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageLayoutView;
+use PHPUnit\Framework\TestCase;
 
-class AbstractPageLayoutViewTest extends \PHPUnit\Framework\TestCase
+class AbstractPageLayoutViewTest extends TestCase
 {
     /**
      * @var ViewModel

--- a/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/StaticPageContentViewTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/StaticPageContentViewTest.php
@@ -3,6 +3,8 @@
 namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\Exception\UnassignedViewVarException;
+use Ingenerator\KohanaView\TemplateSpecifyingViewModel;
+use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\KohanaView\ViewModel\PageLayout\StaticPageContentView;
 use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
@@ -12,14 +14,14 @@ class StaticPageContentViewTest extends TestCase
     public function test_it_is_initialisable()
     {
         $subject = $this->newSubject();
-        $this->assertInstanceOf('Ingenerator\KohanaView\ViewModel\PageLayout\StaticPageContentView', $subject);
-        $this->assertInstanceOf('Ingenerator\KohanaView\ViewModel\PageContentView', $subject);
+        $this->assertInstanceOf(StaticPageContentView::class, $subject);
+        $this->assertInstanceOf(PageContentView::class, $subject);
     }
 
     public function test_it_is_a_template_specifying_view()
     {
         $this->assertInstanceOf(
-            'Ingenerator\KohanaView\TemplateSpecifyingViewModel',
+            TemplateSpecifyingViewModel::class,
             $this->newSubject()
         );
     }

--- a/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/StaticPageContentViewTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/StaticPageContentViewTest.php
@@ -4,9 +4,10 @@ namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\Exception\UnassignedViewVarException;
 use Ingenerator\KohanaView\ViewModel\PageLayout\StaticPageContentView;
+use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
 
-class StaticPageContentViewTest extends \PHPUnit\Framework\TestCase
+class StaticPageContentViewTest extends TestCase
 {
     public function test_it_is_initialisable()
     {

--- a/tests/unit/Ingenerator/KohanaView/ViewTemplateSelectorTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewTemplateSelectorTest.php
@@ -4,12 +4,12 @@ namespace test\unit\Ingenerator\KohanaView;
 
 use DateTime;
 use Ingenerator\KohanaView\Exception\UnspecifiedTemplateNameException;
-use Ingenerator\KohanaView\ViewModel;
 use Ingenerator\KohanaView\ViewTemplateSelector;
+use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\FixedTemplateViewModelStub;
 use test\mock\ViewModel\ViewModelDummy;
 
-class ViewTemplateSelectorTest extends \PHPUnit\Framework\TestCase
+class ViewTemplateSelectorTest extends TestCase
 {
     public function test_it_is_initialisable()
     {

--- a/tests/unit/Ingenerator/KohanaView/ViewTemplateSelectorTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewTemplateSelectorTest.php
@@ -13,7 +13,7 @@ class ViewTemplateSelectorTest extends TestCase
 {
     public function test_it_is_initialisable()
     {
-        $this->assertInstanceOf('Ingenerator\KohanaView\ViewTemplateSelector', $this->newSubject());
+        $this->assertInstanceOf(ViewTemplateSelector::class, $this->newSubject());
     }
 
     /**


### PR DESCRIPTION
Quite a lot of the rector rules we'd want to use depend on us bumping php version and/or adding concrete types to things (which will be in the 5.x branch) but this at least gets the easy things out first.