### PR TITLE
chore: Drop support for PHP 8.2 and 8.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         php_version:
-        - '8.2'
-        - '8.3'
         - '8.4'
         dependency-versions:
         - 'default'
@@ -56,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.4"
           ini-values: "zend.exception_ignore_args=Off"
           coverage: none
 
@@ -74,7 +72,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.4"
           ini-values: "zend.exception_ignore_args=Off"
           coverage: none
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,10 +6,10 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
 
-$finder = (new Finder())
+$finder = new Finder()
     ->in(__DIR__);
 
-return (new Config())
+return new Config()
     ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules([

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-#
+
+* Drop support for PHP < 8.4
 
 ## 4.9.0 (2025-10-03)
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     ],
     "require": {
         "composer/installers": "^1.12 || ^2.0",
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.4.0",
         "ingenerator/kohana-core": "^4.9.0"
     },
     "require-dev": {

--- a/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
+++ b/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
@@ -3,6 +3,7 @@
 namespace test\mock\CFSWrapper;
 
 use Ingenerator\KohanaView\TemplateManager\CFSWrapper;
+use Override;
 
 use function file_exists;
 
@@ -18,6 +19,7 @@ class SingleDirectoryCFSWrapperMock extends CFSWrapper
     {
     }
 
+    #[Override]
     public function find_file($dir, $file)
     {
         $path = $this->root_path.'/'.$dir.'/'.$file.EXT;

--- a/tests/mock/ViewModel/PageLayout/DummyIntermediateLayoutView.php
+++ b/tests/mock/ViewModel/PageLayout/DummyIntermediateLayoutView.php
@@ -4,12 +4,14 @@ namespace test\mock\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractIntermediateLayoutView;
 use Ingenerator\KohanaView\ViewModel\PageLayoutView;
+use Override;
 
 class DummyIntermediateLayoutView extends AbstractIntermediateLayoutView
 {
     /**
      * @return PageLayoutView
      */
+    #[Override]
     public function getUltimatePageView()
     {
         return parent::getUltimatePageView();

--- a/tests/mock/ViewModel/PageLayout/DummyNestedChildView.php
+++ b/tests/mock/ViewModel/PageLayout/DummyNestedChildView.php
@@ -4,12 +4,14 @@ namespace test\mock\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractNestedChildView;
 use Ingenerator\KohanaView\ViewModel\PageLayoutView;
+use Override;
 
 class DummyNestedChildView extends AbstractNestedChildView
 {
     /**
      * @return PageLayoutView
      */
+    #[Override]
     public function getUltimatePageView()
     {
         return parent::getUltimatePageView();

--- a/tests/unit/Ingenerator/KohanaView/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Ingenerator/KohanaView/Renderer/HTMLRendererTest.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
+use Override;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\ViewModelDummy;
@@ -213,6 +214,7 @@ class ViewTemplateSelectorSpy extends ViewTemplateSelector
 
     protected $calls = [];
 
+    #[Override]
     public function getTemplateName(ViewModel $view)
     {
         $this->calls[] = $view;

--- a/tests/unit/Ingenerator/KohanaView/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/Ingenerator/KohanaView/TemplateManager/CFSTemplateManagerTest.php
@@ -9,6 +9,7 @@ use Ingenerator\KohanaView\TemplateManager;
 use Ingenerator\KohanaView\TemplateManager\CFSTemplateManager;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use Override;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use test\mock\CFSWrapper\SingleDirectoryCFSWrapperMock;
@@ -194,6 +195,7 @@ class SpyingTemplateCompiler extends TemplateCompiler
     {
     }
 
+    #[Override]
     public function compile($source)
     {
         $this->compiled[] = $source;

--- a/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
+++ b/tests/unit/Ingenerator/KohanaView/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
@@ -2,6 +2,7 @@
 
 namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
 
+use Override;
 use test\mock\ViewModel\PageLayout\DummyIntermediateLayoutView;
 
 class AbstractIntermediateLayoutViewTest extends AbstractNestedChildViewTest
@@ -13,6 +14,7 @@ class AbstractIntermediateLayoutViewTest extends AbstractNestedChildViewTest
         $this->assertSame('<p>I am the middle bit of your page</p>', $subject->child_html);
     }
 
+    #[Override]
     protected function newSubject()
     {
         return new DummyIntermediateLayoutView($this->parent_view);


### PR DESCRIPTION
The 5.x series will use property hooks and therefore requires >= 8.4.