### PR TITLE
fix: Incorrect file location for some view tests

### DIFF
--- a/tests/unit/ViewModel/AbstractViewModelTest.php
+++ b/tests/unit/ViewModel/AbstractViewModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\unit\Ingenerator\KohanaView\ViewModel;
+namespace test\unit\ViewModel;
 
 use Ingenerator\KohanaView\Exception\InvalidDisplayVariablesException;
 use Ingenerator\KohanaView\Exception\InvalidViewVarAssignmentException;

--- a/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
+namespace test\unit\ViewModel\PageLayout;
 
 use Override;
 use test\mock\ViewModel\PageLayout\DummyIntermediateLayoutView;

--- a/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
+namespace test\unit\ViewModel\PageLayout;
 
 use BadMethodCallException;
 use Ingenerator\KohanaView\ViewModel\NestedChildView;

--- a/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
+namespace test\unit\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel;
 use Ingenerator\KohanaView\ViewModel\PageContentView;

--- a/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
+namespace test\unit\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel;
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageLayoutView;

--- a/tests/unit/ViewModel/PageLayout/StaticPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/StaticPageContentViewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\unit\Ingenerator\KohanaView\ViewModel\PageLayout;
+namespace test\unit\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\Exception\UnassignedViewVarException;
 use Ingenerator\KohanaView\TemplateSpecifyingViewModel;


### PR DESCRIPTION
These were moved by phpstorm in #33 but it placed them in the wrong path so they were not being run by phpunit.