### PR TITLE
refactor: Add strict types throughout

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -64,6 +64,5 @@ return new Config()
                 'var',
             ],
         ],
-        'declare_strict_types' => false,
     ])
     ->setFinder($finder);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -64,8 +64,6 @@ return new Config()
                 'var',
             ],
         ],
-        // -- Disabled until we go to 5.x
-        'void_return' => false,
         'declare_strict_types' => false,
     ])
     ->setFinder($finder);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,8 +15,7 @@ return new Config()
     ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules([
-        // @todo: Bump to php84 migration when we drop 8.2 support
-        '@PHP82Migration' => true,
+        '@PHP84Migration' => true,
         '@PHP82Migration:risky' => true,
         '@PHPUnit10x0Migration:risky' => true,
         // --- Initial set taken from Behat/Behat

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "ingenerator/kohana-dependencies": "^1.3.0",
         "phpunit/phpunit": "^12.3.15",
         "friendsofphp/php-cs-fixer": "^3.88",
-        "rector/rector": "^2.2"
+        "rector/rector": "^2.2",
+        "ingenerator/risky-rector-rules": "dev-main@dev"
     },
     "suggest": {
         "ingenerator/kohana-dependencies": "Dependency Injection container for Kohana 3.x"

--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,7 @@
         "ingenerator/kohana-dependencies": "^1.3.0",
         "phpunit/phpunit": "^12.3.15",
         "friendsofphp/php-cs-fixer": "^3.88",
-        "rector/rector": "^2.2",
-        "ingenerator/risky-rector-rules": "dev-main@dev"
+        "rector/rector": "^2.2"
     },
     "suggest": {
         "ingenerator/kohana-dependencies": "Dependency Injection container for Kohana 3.x"

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "ingenerator/kohana-dependencies": "^1.3.0",
         "phpunit/phpunit": "^12.3.15",
         "friendsofphp/php-cs-fixer": "^3.88",
-        "rector/rector": "^2.1"
+        "rector/rector": "^2.1",
+        "ingenerator/risky-rector-rules": "dev-main@dev"
     },
     "suggest": {
         "ingenerator/kohana-dependencies": "Dependency Injection container for Kohana 3.x"

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "ingenerator/kohana-dependencies": "^1.3.0",
         "phpunit/phpunit": "^12.3.15",
         "friendsofphp/php-cs-fixer": "^3.88",
-        "rector/rector": "^2.1",
+        "rector/rector": "2.2.2",
         "ingenerator/risky-rector-rules": "dev-main@dev"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "ingenerator/kohana-dependencies": "^1.3.0",
         "phpunit/phpunit": "^12.3.15",
         "friendsofphp/php-cs-fixer": "^3.88",
-        "rector/rector": "2.2.2",
+        "rector/rector": "^2.2",
         "ingenerator/risky-rector-rules": "dev-main@dev"
     },
     "suggest": {

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Ingenerator\KohanaView\Renderer\HTMLRenderer;
 use Ingenerator\KohanaView\Renderer\PageLayoutRenderer;
 use Ingenerator\KohanaView\TemplateCompiler;

--- a/config/kohanaview.php
+++ b/config/kohanaview.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Configuration for the KohanaView module.
  */

--- a/koharness.php
+++ b/koharness.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     'syspath' => __DIR__.'/vendor/ingenerator/kohana-core',
     'modules' => [

--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector;
 
@@ -23,8 +22,6 @@ return RectorConfig::configure()
     ->withPhpSets()
     ->withAttributesSets(all: true)
     ->withSkip([
-        // Temporarily disable while we're doing typehinting to avoid mixing these in
-        ClassPropertyAssignToConstructorPromotionRector::class,
         ClosureToArrowFunctionRector::class => [
             // Needs to be a traditional function in order to restrict the scope
             __DIR__.'/src/Renderer/HTMLRenderer.php',

--- a/rector.php
+++ b/rector.php
@@ -2,9 +2,6 @@
 
 declare(strict_types=1);
 
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddPropertyTypeFromPhpDocRector;
-use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
@@ -43,9 +40,4 @@ return RectorConfig::configure()
     ])
     ->withImportNames(
         removeUnusedImports: true,
-    )
-    ->withRules([
-        AddPropertyTypeFromPhpDocRector::class,
-        AddParamTypeFromPhpDocRector::class,
-        AddReturnTypeFromPhpDocRector::class,
-    ]);
+    );

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddPropertyTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
@@ -40,4 +41,9 @@ return RectorConfig::configure()
     ])
     ->withImportNames(
         removeUnusedImports: true,
-    );
+    )
+    ->withRules([
+        AddPropertyTypeFromPhpDocRector::class,
+        Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector::class,
+        Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector::class,
+    ]);

--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
+use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -15,14 +17,21 @@ return RectorConfig::configure()
     ->withRootFiles()
     ->withPreparedSets(
         codeQuality: true,
+        typeDeclarations: true,
         earlyReturn: true,
     )
     ->withPhpSets()
     ->withAttributesSets(all: true)
     ->withSkip([
+        // Temporarily disable while we're doing typehinting to avoid mixing these in
+        ClassPropertyAssignToConstructorPromotionRector::class,
         ClosureToArrowFunctionRector::class => [
             // Needs to be a traditional function in order to restrict the scope
             __DIR__.'/src/Renderer/HTMLRenderer.php',
+        ],
+        AddFunctionVoidReturnTypeWhereNoReturnRector::class => [
+            // This stub function shouldn't return `void` as it will actually "return" a string
+            __DIR__.'/src/raw_fn_stub.php',
         ],
         ReturnNeverTypeRector::class => [
             // This stub function shouldn't return `never` as it will actually "return" a string

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector;
 use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddPropertyTypeFromPhpDocRector;
+use Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector;
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
@@ -44,6 +46,6 @@ return RectorConfig::configure()
     )
     ->withRules([
         AddPropertyTypeFromPhpDocRector::class,
-        Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddParamTypeFromPhpDocRector::class,
-        Ingenerator\RiskyRectorRules\PhpDocToStrictTypes\AddReturnTypeFromPhpDocRector::class,
+        AddParamTypeFromPhpDocRector::class,
+        AddReturnTypeFromPhpDocRector::class,
     ]);

--- a/src/Exception/InvalidDisplayVariablesException.php
+++ b/src/Exception/InvalidDisplayVariablesException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Exception;
 
 use InvalidArgumentException;

--- a/src/Exception/InvalidDisplayVariablesException.php
+++ b/src/Exception/InvalidDisplayVariablesException.php
@@ -16,10 +16,8 @@ class InvalidDisplayVariablesException extends InvalidArgumentException
     /**
      * @param string $view_class
      * @param string[] $errors
-     *
-     * @return static
      */
-    public static function passedToDisplay($view_class, $errors)
+    public static function passedToDisplay($view_class, $errors): static
     {
         return new static(
             sprintf(

--- a/src/Exception/InvalidDisplayVariablesException.php
+++ b/src/Exception/InvalidDisplayVariablesException.php
@@ -14,10 +14,9 @@ use function sprintf;
 class InvalidDisplayVariablesException extends InvalidArgumentException
 {
     /**
-     * @param string $view_class
      * @param string[] $errors
      */
-    public static function passedToDisplay($view_class, $errors): static
+    public static function passedToDisplay(string $view_class, array $errors): static
     {
         return new static(
             sprintf(

--- a/src/Exception/InvalidTemplateContentException.php
+++ b/src/Exception/InvalidTemplateContentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Exception;
 
 use InvalidArgumentException;

--- a/src/Exception/InvalidTemplateContentException.php
+++ b/src/Exception/InvalidTemplateContentException.php
@@ -16,7 +16,7 @@ class InvalidTemplateContentException extends InvalidArgumentException
         );
     }
 
-    public static function hasLegacyRawEscapePrefix($source_fragment): static
+    public static function hasLegacyRawEscapePrefix(string $source_fragment): static
     {
         return new static(
             "Invalid legacy-style <?=! raw escape prefix in template, please change `$source_fragment` to use `<?=raw()`"

--- a/src/Exception/InvalidTemplateContentException.php
+++ b/src/Exception/InvalidTemplateContentException.php
@@ -9,11 +9,7 @@ use InvalidArgumentException;
  */
 class InvalidTemplateContentException extends InvalidArgumentException
 {
-    /**
-     * @param string $escape_method
-     * @param string $source_fragment
-     */
-    public static function containsImplicitDoubleEscape($escape_method, $source_fragment): static
+    public static function containsImplicitDoubleEscape(string $escape_method, string $source_fragment): static
     {
         return new static(
             "Invalid implicit double-escape in template - remove $escape_method from `$source_fragment` or mark as raw"

--- a/src/Exception/InvalidTemplateContentException.php
+++ b/src/Exception/InvalidTemplateContentException.php
@@ -12,31 +12,29 @@ class InvalidTemplateContentException extends InvalidArgumentException
     /**
      * @param string $escape_method
      * @param string $source_fragment
-     *
-     * @return static
      */
-    public static function containsImplicitDoubleEscape($escape_method, $source_fragment)
+    public static function containsImplicitDoubleEscape($escape_method, $source_fragment): static
     {
         return new static(
             "Invalid implicit double-escape in template - remove $escape_method from `$source_fragment` or mark as raw"
         );
     }
 
-    public static function hasLegacyRawEscapePrefix($source_fragment)
+    public static function hasLegacyRawEscapePrefix($source_fragment): static
     {
         return new static(
             "Invalid legacy-style <?=! raw escape prefix in template, please change `$source_fragment` to use `<?=raw()`"
         );
     }
 
-    public static function hasLegacyPhpEcho()
+    public static function hasLegacyPhpEcho(): static
     {
         return new static(
             'Invalid legacy-style use of `<?php echo` to avoid automatic escaping : use `<?=raw()` instead'
         );
     }
 
-    public static function forEmptyTemplate()
+    public static function forEmptyTemplate(): static
     {
         return new static('Cannot compile empty template');
     }

--- a/src/Exception/InvalidViewVarAssignmentException.php
+++ b/src/Exception/InvalidViewVarAssignmentException.php
@@ -10,12 +10,9 @@ use BadMethodCallException;
 class InvalidViewVarAssignmentException extends BadMethodCallException
 {
     /**
-     * @param string $view_class
-     * @param string $var_name
-     *
      * @return static
      */
-    public static function forReadOnlyVar($view_class, $var_name)
+    public static function forReadOnlyVar(string $view_class, string $var_name)
     {
         return new static(
             $view_class.' variables are read-only, cannot assign '.$var_name

--- a/src/Exception/InvalidViewVarAssignmentException.php
+++ b/src/Exception/InvalidViewVarAssignmentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Exception;
 
 use BadMethodCallException;

--- a/src/Exception/InvalidViewVarAssignmentException.php
+++ b/src/Exception/InvalidViewVarAssignmentException.php
@@ -9,10 +9,7 @@ use BadMethodCallException;
  */
 class InvalidViewVarAssignmentException extends BadMethodCallException
 {
-    /**
-     * @return static
-     */
-    public static function forReadOnlyVar(string $view_class, string $var_name)
+    public static function forReadOnlyVar(string $view_class, string $var_name): static
     {
         return new static(
             $view_class.' variables are read-only, cannot assign '.$var_name

--- a/src/Exception/TemplateCacheException.php
+++ b/src/Exception/TemplateCacheException.php
@@ -9,20 +9,14 @@ use RuntimeException;
  */
 class TemplateCacheException extends RuntimeException
 {
-    /**
-     * @param string $path
-     */
-    public static function cannotCreateDirectory($path): static
+    public static function cannotCreateDirectory(string $path): static
     {
         return new static(
             "Cannot create template cache directory in '$path'"
         );
     }
 
-    /**
-     * @param string $path
-     */
-    public static function pathNotWriteable($path): static
+    public static function pathNotWriteable(string $path): static
     {
         return new static("Cannot write to compiled template path '$path'");
     }

--- a/src/Exception/TemplateCacheException.php
+++ b/src/Exception/TemplateCacheException.php
@@ -11,10 +11,8 @@ class TemplateCacheException extends RuntimeException
 {
     /**
      * @param string $path
-     *
-     * @return static
      */
-    public static function cannotCreateDirectory($path)
+    public static function cannotCreateDirectory($path): static
     {
         return new static(
             "Cannot create template cache directory in '$path'"
@@ -23,10 +21,8 @@ class TemplateCacheException extends RuntimeException
 
     /**
      * @param string $path
-     *
-     * @return static
      */
-    public static function pathNotWriteable($path)
+    public static function pathNotWriteable($path): static
     {
         return new static("Cannot write to compiled template path '$path'");
     }

--- a/src/Exception/TemplateCacheException.php
+++ b/src/Exception/TemplateCacheException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Exception;
 
 use RuntimeException;

--- a/src/Exception/TemplateNotFoundException.php
+++ b/src/Exception/TemplateNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Exception;
 
 use InvalidArgumentException;

--- a/src/Exception/TemplateNotFoundException.php
+++ b/src/Exception/TemplateNotFoundException.php
@@ -9,20 +9,14 @@ use InvalidArgumentException;
  */
 class TemplateNotFoundException extends InvalidArgumentException
 {
-    /**
-     * @param string $path
-     */
-    public static function forFullPath($path): static
+    public static function forFullPath(string $path): static
     {
         return new static(
             "Failed to include template '$path'"
         );
     }
 
-    /**
-     * @param string $rel_path
-     */
-    public static function forSourcePath($rel_path): static
+    public static function forSourcePath(string $rel_path): static
     {
         return new static(
             "Cannot find template source file '$rel_path'"

--- a/src/Exception/TemplateNotFoundException.php
+++ b/src/Exception/TemplateNotFoundException.php
@@ -11,10 +11,8 @@ class TemplateNotFoundException extends InvalidArgumentException
 {
     /**
      * @param string $path
-     *
-     * @return static
      */
-    public static function forFullPath($path)
+    public static function forFullPath($path): static
     {
         return new static(
             "Failed to include template '$path'"
@@ -23,10 +21,8 @@ class TemplateNotFoundException extends InvalidArgumentException
 
     /**
      * @param string $rel_path
-     *
-     * @return static
      */
-    public static function forSourcePath($rel_path)
+    public static function forSourcePath($rel_path): static
     {
         return new static(
             "Cannot find template source file '$rel_path'"

--- a/src/Exception/UnassignedViewVarException.php
+++ b/src/Exception/UnassignedViewVarException.php
@@ -15,10 +15,8 @@ class UnassignedViewVarException extends BadMethodCallException
      * @param string $view_class
      * @param string $var_name
      * @param string $hint
-     *
-     * @return static
      */
-    public static function forVariable($view_class, $var_name, $hint)
+    public static function forVariable($view_class, $var_name, $hint): static
     {
         return new static(
             sprintf(

--- a/src/Exception/UnassignedViewVarException.php
+++ b/src/Exception/UnassignedViewVarException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Exception;
 
 use BadMethodCallException;

--- a/src/Exception/UnassignedViewVarException.php
+++ b/src/Exception/UnassignedViewVarException.php
@@ -11,12 +11,7 @@ use function sprintf;
  */
 class UnassignedViewVarException extends BadMethodCallException
 {
-    /**
-     * @param string $view_class
-     * @param string $var_name
-     * @param string $hint
-     */
-    public static function forVariable($view_class, $var_name, $hint): static
+    public static function forVariable(string $view_class, string $var_name, string $hint): static
     {
         return new static(
             sprintf(

--- a/src/Exception/UndefinedViewVarException.php
+++ b/src/Exception/UndefinedViewVarException.php
@@ -12,10 +12,8 @@ class UndefinedViewVarException extends BadMethodCallException
     /**
      * @param string $view_class
      * @param string $var_name
-     *
-     * @return static
      */
-    public static function forClassAndVar($view_class, $var_name)
+    public static function forClassAndVar($view_class, $var_name): static
     {
         return new static(
             "$view_class does not define a '$var_name' field"

--- a/src/Exception/UndefinedViewVarException.php
+++ b/src/Exception/UndefinedViewVarException.php
@@ -9,11 +9,7 @@ use BadMethodCallException;
  */
 class UndefinedViewVarException extends BadMethodCallException
 {
-    /**
-     * @param string $view_class
-     * @param string $var_name
-     */
-    public static function forClassAndVar($view_class, $var_name): static
+    public static function forClassAndVar(string $view_class, string $var_name): static
     {
         return new static(
             "$view_class does not define a '$var_name' field"

--- a/src/Exception/UndefinedViewVarException.php
+++ b/src/Exception/UndefinedViewVarException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Exception;
 
 use BadMethodCallException;

--- a/src/Exception/UnspecifiedTemplateNameException.php
+++ b/src/Exception/UnspecifiedTemplateNameException.php
@@ -18,11 +18,7 @@ class UnspecifiedTemplateNameException extends UnexpectedValueException
         );
     }
 
-    /**
-     * @param string $view_class
-     * @param string $template
-     */
-    public static function forNonStringValue($view_class, $template): static
+    public static function forNonStringValue(string $view_class, string $template): static
     {
         return new static(
             sprintf(

--- a/src/Exception/UnspecifiedTemplateNameException.php
+++ b/src/Exception/UnspecifiedTemplateNameException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Exception;
 
 use UnexpectedValueException;

--- a/src/Exception/UnspecifiedTemplateNameException.php
+++ b/src/Exception/UnspecifiedTemplateNameException.php
@@ -11,10 +11,7 @@ use function sprintf;
  */
 class UnspecifiedTemplateNameException extends UnexpectedValueException
 {
-    /**
-     * @return static
-     */
-    public static function forEmptyValue(string $view_class)
+    public static function forEmptyValue(string $view_class): static
     {
         return new static(
             $view_class.'::getTemplateName() must return a template name, empty value returned'
@@ -24,10 +21,8 @@ class UnspecifiedTemplateNameException extends UnexpectedValueException
     /**
      * @param string $view_class
      * @param string $template
-     *
-     * @return static
      */
-    public static function forNonStringValue($view_class, $template)
+    public static function forNonStringValue($view_class, $template): static
     {
         return new static(
             sprintf(

--- a/src/Exception/UnspecifiedTemplateNameException.php
+++ b/src/Exception/UnspecifiedTemplateNameException.php
@@ -12,11 +12,9 @@ use function sprintf;
 class UnspecifiedTemplateNameException extends UnexpectedValueException
 {
     /**
-     * @param string $view_class
-     *
      * @return static
      */
-    public static function forEmptyValue($view_class)
+    public static function forEmptyValue(string $view_class)
     {
         return new static(
             $view_class.'::getTemplateName() must return a template name, empty value returned'

--- a/src/Exception/UnspecifiedTemplateNameException.php
+++ b/src/Exception/UnspecifiedTemplateNameException.php
@@ -4,8 +4,6 @@ namespace Ingenerator\KohanaView\Exception;
 
 use UnexpectedValueException;
 
-use function sprintf;
-
 /**
  * Thrown when a TemplateSpecifyingView does not return a valid template name.
  */
@@ -15,17 +13,6 @@ class UnspecifiedTemplateNameException extends UnexpectedValueException
     {
         return new static(
             $view_class.'::getTemplateName() must return a template name, empty value returned'
-        );
-    }
-
-    public static function forNonStringValue(string $view_class, string $template): static
-    {
-        return new static(
-            sprintf(
-                '%s::getTemplateName() must return a string template name, %s value returned',
-                $view_class,
-                get_debug_type($template)
-            )
         );
     }
 }

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView;
 
 /**

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -9,8 +9,5 @@ namespace Ingenerator\KohanaView;
  */
 interface Renderer
 {
-    /**
-     * @return string
-     */
-    public function render(ViewModel $view);
+    public function render(ViewModel $view): string;
 }

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -49,10 +49,7 @@ class HTMLRenderer implements Renderer
         return $template;
     }
 
-    /**
-     * @param string $template_path
-     */
-    protected function includeWithAnonymousScope(ViewModel $view, $template_path)
+    protected function includeWithAnonymousScope(ViewModel $view, string $template_path)
     {
         /** @noinspection PhpUnusedParameterInspection */
         /** @noinspection PhpDocSignatureInspection */

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Renderer;
 
 use Ingenerator\KohanaView\Exception\TemplateNotFoundException;

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -41,10 +41,7 @@ class HTMLRenderer implements Renderer
         return $output;
     }
 
-    /**
-     * @return string
-     */
-    protected function getTemplatePath(ViewModel $view)
+    protected function getTemplatePath(ViewModel $view): string
     {
         $template_name = $this->template_selector->getTemplateName($view);
         $template = $this->template_manager->getPath($template_name);

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -56,7 +56,7 @@ class HTMLRenderer implements Renderer
         return $template;
     }
 
-    protected function includeWithAnonymousScope(ViewModel $view, string $template_path)
+    protected function includeWithAnonymousScope(ViewModel $view, string $template_path): void
     {
         /** @noinspection PhpUnusedParameterInspection */
         /** @noinspection PhpDocSignatureInspection */

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -27,7 +27,7 @@ class HTMLRenderer implements Renderer
         $this->template_manager = $template_manager;
     }
 
-    public function render(ViewModel $view)
+    public function render(ViewModel $view): string|false
     {
         $template_path = $this->getTemplatePath($view);
 

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -7,6 +7,7 @@ use Ingenerator\KohanaView\Renderer;
 use Ingenerator\KohanaView\TemplateManager;
 use Ingenerator\KohanaView\ViewModel;
 use Ingenerator\KohanaView\ViewTemplateSelector;
+use RuntimeException;
 
 use function ob_get_clean;
 use function ob_start;
@@ -27,7 +28,7 @@ class HTMLRenderer implements Renderer
         $this->template_manager = $template_manager;
     }
 
-    public function render(ViewModel $view): string|false
+    public function render(ViewModel $view): string
     {
         $template_path = $this->getTemplatePath($view);
 
@@ -36,6 +37,12 @@ class HTMLRenderer implements Renderer
             $this->includeWithAnonymousScope($view, $template_path);
         } finally {
             $output = ob_get_clean();
+        }
+
+        if ($output === false) {
+            // Has code within the view cleared out our output buffering? Whatever, we no longer have access
+            // to the expected content.
+            throw new RuntimeException('Could not render view: output buffering is not active');
         }
 
         return $output;

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -18,14 +18,10 @@ use function ob_start;
  */
 class HTMLRenderer implements Renderer
 {
-    protected TemplateManager $template_manager;
-
-    protected ViewTemplateSelector $template_selector;
-
-    public function __construct(ViewTemplateSelector $template_selector, TemplateManager $template_manager)
-    {
-        $this->template_selector = $template_selector;
-        $this->template_manager = $template_manager;
+    public function __construct(
+        protected ViewTemplateSelector $template_selector,
+        protected TemplateManager $template_manager,
+    ) {
     }
 
     public function render(ViewModel $view): string

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -17,15 +17,9 @@ use function ob_start;
  */
 class HTMLRenderer implements Renderer
 {
-    /**
-     * @var TemplateManager
-     */
-    protected $template_manager;
+    protected TemplateManager $template_manager;
 
-    /**
-     * @var ViewTemplateSelector
-     */
-    protected $template_selector;
+    protected ViewTemplateSelector $template_selector;
 
     public function __construct(ViewTemplateSelector $template_selector, TemplateManager $template_manager)
     {

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -26,10 +26,7 @@ use Request;
  */
 class PageLayoutRenderer
 {
-    /**
-     * @var bool Whether to force (or not force) embedding the content in the layout
-     */
-    protected bool $use_layout;
+    protected ?bool $use_layout = null;
 
     protected Renderer $view_renderer;
 
@@ -64,18 +61,14 @@ class PageLayoutRenderer
 
     protected function shouldUseLayout(): bool
     {
-        if ($this->use_layout !== null) {
-            return $this->use_layout;
-        }
-
-        return ! ($this->current_request && $this->current_request->is_ajax());
+        return $this->use_layout ?? ! ($this->current_request && $this->current_request->is_ajax());
     }
 
     /**
      * Configure whether to always wrap the content in the layout (TRUE), never (FALSE) or automatically for
      * non-AJAX requests (NULL).
      */
-    public function setUseLayout(bool $use_layout): void
+    public function setUseLayout(?bool $use_layout): void
     {
         $this->use_layout = $use_layout;
     }

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -74,10 +74,8 @@ class PageLayoutRenderer
     /**
      * Configure whether to always wrap the content in the layout (TRUE), never (FALSE) or automatically for
      * non-AJAX requests (NULL).
-     *
-     * @param bool $use_layout
      */
-    public function setUseLayout($use_layout): void
+    public function setUseLayout(bool $use_layout): void
     {
         $this->use_layout = $use_layout;
     }

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -41,10 +41,7 @@ class PageLayoutRenderer
         $this->current_request = $current_request;
     }
 
-    /**
-     * @return string
-     */
-    public function render(NestedChildView $content_view)
+    public function render(NestedChildView $content_view): string
     {
         $content = $this->view_renderer->render($content_view);
         if ( ! $this->shouldUseLayout()) {
@@ -54,10 +51,7 @@ class PageLayoutRenderer
         return $this->renderParent($content_view->getParentView(), $content);
     }
 
-    /**
-     * @return string
-     */
-    protected function renderParent(NestedParentView $parent, $content_html)
+    protected function renderParent(NestedParentView $parent, $content_html): string
     {
         $parent->setBodyHTML($content_html);
 
@@ -68,10 +62,7 @@ class PageLayoutRenderer
         return $this->view_renderer->render($parent);
     }
 
-    /**
-     * @return bool
-     */
-    protected function shouldUseLayout()
+    protected function shouldUseLayout(): bool
     {
         if ($this->use_layout !== null) {
             return $this->use_layout;

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -51,7 +51,7 @@ class PageLayoutRenderer
         return $this->renderParent($content_view->getParentView(), $content);
     }
 
-    protected function renderParent(NestedParentView $parent, $content_html): string
+    protected function renderParent(NestedParentView $parent, string $content_html): string
     {
         $parent->setBodyHTML($content_html);
 

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -28,14 +28,10 @@ class PageLayoutRenderer
 {
     protected ?bool $use_layout = null;
 
-    protected Renderer $view_renderer;
-
-    protected ?Request $current_request;
-
-    public function __construct(Renderer $view_renderer, ?Request $current_request = null)
-    {
-        $this->view_renderer = $view_renderer;
-        $this->current_request = $current_request;
+    public function __construct(
+        protected Renderer $view_renderer,
+        protected ?Request $current_request = null,
+    ) {
     }
 
     public function render(NestedChildView $content_view): string

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -31,15 +31,9 @@ class PageLayoutRenderer
      */
     protected $use_layout;
 
-    /**
-     * @var Renderer
-     */
-    protected $view_renderer;
+    protected Renderer $view_renderer;
 
-    /**
-     * @var Request
-     */
-    protected $current_request;
+    protected ?Request $current_request;
 
     public function __construct(Renderer $view_renderer, ?Request $current_request = null)
     {

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\Renderer;
 
 use Ingenerator\KohanaView\Renderer;

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -29,7 +29,7 @@ class PageLayoutRenderer
     /**
      * @var bool Whether to force (or not force) embedding the content in the layout
      */
-    protected $use_layout;
+    protected bool $use_layout;
 
     protected Renderer $view_renderer;
 

--- a/src/Renderer/PageLayoutRenderer.php
+++ b/src/Renderer/PageLayoutRenderer.php
@@ -85,10 +85,8 @@ class PageLayoutRenderer
      * non-AJAX requests (NULL).
      *
      * @param bool $use_layout
-     *
-     * @return void
      */
-    public function setUseLayout($use_layout)
+    public function setUseLayout($use_layout): void
     {
         $this->use_layout = $use_layout;
     }

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -50,7 +50,7 @@ class TemplateCompiler
      */
     public function compile(string $source): ?string
     {
-        if ( ! $source) {
+        if ($source === '' || $source === '0') {
             throw InvalidTemplateContentException::forEmptyTemplate();
         }
 

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -46,11 +46,9 @@ class TemplateCompiler
      * Compile a string containing a PHP template, automatically escaping variables that are echoed in PHP short tags,
      * and return the compiled PHP string.
      *
-     * @param string $source
-     *
      * @throws InvalidArgumentException if the template is empty or invalid
      */
-    public function compile($source): ?string
+    public function compile(string $source): ?string
     {
         if ( ! $source) {
             throw InvalidTemplateContentException::forEmptyTemplate();
@@ -97,11 +95,7 @@ class TemplateCompiler
         return $compiled;
     }
 
-    /**
-     * @param string $string
-     * @param string $prefix
-     */
-    protected function startsWith($string, $prefix): bool
+    protected function startsWith(string $string, string $prefix): bool
     {
         return str_starts_with($string, $prefix);
     }

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView;
 
 use Ingenerator\KohanaView\Exception\InvalidTemplateContentException;

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -100,10 +100,8 @@ class TemplateCompiler
     /**
      * @param string $string
      * @param string $prefix
-     *
-     * @return bool
      */
-    protected function startsWith($string, $prefix)
+    protected function startsWith($string, $prefix): bool
     {
         return str_starts_with($string, $prefix);
     }

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -48,11 +48,9 @@ class TemplateCompiler
      *
      * @param string $source
      *
-     * @return string
-     *
      * @throws InvalidArgumentException if the template is empty or invalid
      */
-    public function compile($source)
+    public function compile($source): ?string
     {
         if ( ! $source) {
             throw InvalidTemplateContentException::forEmptyTemplate();

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -33,10 +33,7 @@ use function trim;
  */
 class TemplateCompiler
 {
-    /**
-     * @var array
-     */
-    protected $options = [
+    protected array $options = [
         'escape_method' => 'HTML::chars',
     ];
 

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -66,7 +66,7 @@ class TemplateCompiler
     /**
      * @param string[] $matches
      */
-    protected function compilePhpShortTag($matches): string
+    protected function compilePhpShortTag(array $matches): string
     {
         $var = trim($matches[1]);
         $terminator = $matches[2];

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -65,10 +65,8 @@ class TemplateCompiler
 
     /**
      * @param string[] $matches
-     *
-     * @return string
      */
-    protected function compilePhpShortTag($matches)
+    protected function compilePhpShortTag($matches): string
     {
         $var = trim($matches[1]);
         $terminator = $matches[2];

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -50,7 +50,7 @@ class TemplateCompiler
      */
     public function compile(string $source): ?string
     {
-        if ($source === '' || $source === '0') {
+        if ($source === '') {
             throw InvalidTemplateContentException::forEmptyTemplate();
         }
 

--- a/src/TemplateCompiler.php
+++ b/src/TemplateCompiler.php
@@ -48,7 +48,7 @@ class TemplateCompiler
      *
      * @throws InvalidArgumentException if the template is empty or invalid
      */
-    public function compile(string $source): ?string
+    public function compile(string $source): string
     {
         if ($source === '') {
             throw InvalidTemplateContentException::forEmptyTemplate();

--- a/src/TemplateManager.php
+++ b/src/TemplateManager.php
@@ -13,5 +13,5 @@ interface TemplateManager
      *
      * @return string Path to the compiled template file
      */
-    public function getPath($template_name);
+    public function getPath($template_name): string;
 }

--- a/src/TemplateManager.php
+++ b/src/TemplateManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView;
 
 /**

--- a/src/TemplateManager.php
+++ b/src/TemplateManager.php
@@ -13,5 +13,5 @@ interface TemplateManager
      *
      * @return string Path to the compiled template file
      */
-    public function getPath($template_name): string;
+    public function getPath(string $template_name): string;
 }

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\TemplateManager;
 
 use Arr;

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -74,10 +74,7 @@ class CFSTemplateManager implements TemplateManager
         return $compiled_path;
     }
 
-    /**
-     * @param string $compiled_path
-     */
-    protected function isCompileRequired($compiled_path): bool
+    protected function isCompileRequired(string $compiled_path): bool
     {
         if ($this->recompile_always && ! isset($this->compiled_paths[$compiled_path])) {
             return true;
@@ -98,20 +95,13 @@ class CFSTemplateManager implements TemplateManager
         return file_get_contents($source_file);
     }
 
-    /**
-     * @param string $compiled_path
-     * @param string $compiled
-     */
-    protected function writeFile($compiled_path, $compiled)
+    protected function writeFile(string $compiled_path, string $compiled)
     {
         $this->ensureWriteableDirectory(dirname($compiled_path));
         file_put_contents($compiled_path, $compiled);
     }
 
-    /**
-     * @param string $path
-     */
-    protected function ensureWriteableDirectory($path)
+    protected function ensureWriteableDirectory(string $path)
     {
         try {
             Kohana::ensureDirectory($path, 0o777);

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -76,10 +76,8 @@ class CFSTemplateManager implements TemplateManager
 
     /**
      * @param string $compiled_path
-     *
-     * @return bool
      */
-    protected function isCompileRequired($compiled_path)
+    protected function isCompileRequired($compiled_path): bool
     {
         if ($this->recompile_always && ! isset($this->compiled_paths[$compiled_path])) {
             return true;

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -92,7 +92,7 @@ class CFSTemplateManager implements TemplateManager
         file_put_contents($compiled_path, $compiled);
     }
 
-    protected function ensureWriteableDirectory(string $path)
+    protected function ensureWriteableDirectory(string $path): void
     {
         try {
             Kohana::ensureDirectory($path, 0o777);

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -89,11 +89,9 @@ class CFSTemplateManager implements TemplateManager
     }
 
     /**
-     * @param string $template_name
-     *
      * @return string
      */
-    protected function requireSourceFileContent($template_name): string|false
+    protected function requireSourceFileContent(string $template_name): string|false
     {
         if ( ! $source_file = $this->cascading_files->find_file($this->template_dir, $template_name)) {
             throw TemplateNotFoundException::forSourcePath($this->template_dir.'/'.$template_name);

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -77,10 +77,7 @@ class CFSTemplateManager implements TemplateManager
         return ! file_exists($compiled_path);
     }
 
-    /**
-     * @return string
-     */
-    protected function requireSourceFileContent(string $template_name): string|false
+    protected function requireSourceFileContent(string $template_name): string
     {
         if ( ! $source_file = $this->cascading_files->find_file($this->template_dir, $template_name)) {
             throw TemplateNotFoundException::forSourcePath($this->template_dir.'/'.$template_name);

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -31,17 +31,11 @@ class CFSTemplateManager implements TemplateManager
 
     protected CFSWrapper $cascading_files;
 
-    /**
-     * @var array
-     */
-    protected $compiled_paths = [];
+    protected array $compiled_paths = [];
 
     protected TemplateCompiler $compiler;
 
-    /**
-     * @var bool
-     */
-    protected $recompile_always;
+    protected bool $recompile_always;
 
     protected string $template_dir;
 

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -86,7 +86,7 @@ class CFSTemplateManager implements TemplateManager
         return file_get_contents($source_file);
     }
 
-    protected function writeFile(string $compiled_path, string $compiled)
+    protected function writeFile(string $compiled_path, string $compiled): void
     {
         $this->ensureWriteableDirectory(dirname($compiled_path));
         file_put_contents($compiled_path, $compiled);

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -27,35 +27,23 @@ use function rtrim;
  */
 class CFSTemplateManager implements TemplateManager
 {
-    /**
-     * @var string
-     */
-    protected $cache_dir;
+    protected string $cache_dir;
 
-    /**
-     * @var CFSWrapper
-     */
-    protected $cascading_files;
+    protected CFSWrapper $cascading_files;
 
     /**
      * @var array
      */
     protected $compiled_paths = [];
 
-    /**
-     * @var TemplateCompiler
-     */
-    protected $compiler;
+    protected TemplateCompiler $compiler;
 
     /**
      * @var bool
      */
     protected $recompile_always;
 
-    /**
-     * @var string
-     */
-    protected $template_dir;
+    protected string $template_dir;
 
     /**
      * Valid options:

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -60,7 +60,7 @@ class CFSTemplateManager implements TemplateManager
         $this->template_dir = rtrim(Arr::get($options, 'template_dir', 'views'), '/');
     }
 
-    public function getPath($template_name)
+    public function getPath($template_name): string
     {
         $compiled_path = $this->cache_dir.'/'.$template_name.'.php';
 

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -93,7 +93,7 @@ class CFSTemplateManager implements TemplateManager
      *
      * @return string
      */
-    protected function requireSourceFileContent($template_name)
+    protected function requireSourceFileContent($template_name): string|false
     {
         if ( ! $source_file = $this->cascading_files->find_file($this->template_dir, $template_name)) {
             throw TemplateNotFoundException::forSourcePath($this->template_dir.'/'.$template_name);

--- a/src/TemplateManager/CFSTemplateManager.php
+++ b/src/TemplateManager/CFSTemplateManager.php
@@ -33,8 +33,6 @@ class CFSTemplateManager implements TemplateManager
 
     protected array $compiled_paths = [];
 
-    protected TemplateCompiler $compiler;
-
     protected bool $recompile_always;
 
     protected string $template_dir;
@@ -45,10 +43,12 @@ class CFSTemplateManager implements TemplateManager
      * * recompile_always => whether to recompile each template on every execution,
      * * template_dir     => directory (in the cascading filesystem) to search for templates
      */
-    public function __construct(TemplateCompiler $compiler, array $options, ?CFSWrapper $cascading_files = null)
-    {
+    public function __construct(
+        protected TemplateCompiler $compiler,
+        array $options,
+        ?CFSWrapper $cascading_files = null,
+    ) {
         $this->cascading_files = $cascading_files ?: new CFSWrapper();
-        $this->compiler = $compiler;
         $this->cache_dir = rtrim((string) $options['cache_dir'], '/');
         $this->recompile_always = Arr::get($options, 'recompile_always', false);
         $this->template_dir = rtrim(Arr::get($options, 'template_dir', 'views'), '/');

--- a/src/TemplateManager/CFSWrapper.php
+++ b/src/TemplateManager/CFSWrapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\TemplateManager;
 
 use Kohana;

--- a/src/TemplateSpecifyingViewModel.php
+++ b/src/TemplateSpecifyingViewModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView;
 
 /**

--- a/src/TemplateSpecifyingViewModel.php
+++ b/src/TemplateSpecifyingViewModel.php
@@ -8,8 +8,5 @@ namespace Ingenerator\KohanaView;
  */
 interface TemplateSpecifyingViewModel
 {
-    /**
-     * @return string
-     */
-    public function getTemplateName();
+    public function getTemplateName(): string;
 }

--- a/src/ViewModel.php
+++ b/src/ViewModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView;
 
 /**

--- a/src/ViewModel.php
+++ b/src/ViewModel.php
@@ -8,8 +8,5 @@ namespace Ingenerator\KohanaView;
  */
 interface ViewModel
 {
-    /**
-     * @return void
-     */
-    public function display(array $variables);
+    public function display(array $variables): void;
 }

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\ViewModel;
 
 use BadMethodCallException;

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -85,11 +85,9 @@ abstract class AbstractViewModel implements ViewModel
     }
 
     /**
-     * @param string $name
-     *
      * @throws BadMethodCallException values cannot be assigned except with the display method
      */
-    public function __set($name, $value)
+    public function __set(string $name, $value)
     {
         throw InvalidViewVarAssignmentException::forReadOnlyVar(static::class, $name);
     }

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -87,7 +87,7 @@ abstract class AbstractViewModel implements ViewModel
     /**
      * @throws BadMethodCallException values cannot be assigned except with the display method
      */
-    public function __set(string $name, mixed $value)
+    public function __set(string $name, mixed $value): void
     {
         throw InvalidViewVarAssignmentException::forReadOnlyVar(static::class, $name);
     }

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -110,7 +110,7 @@ abstract class AbstractViewModel implements ViewModel
     /**
      * @return string[] of errors
      */
-    protected function validateDisplayVariables(array $variables)
+    protected function validateDisplayVariables(array $variables): array
     {
         $errors = [];
         $provided_variables = array_keys($variables);

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -99,7 +99,7 @@ abstract class AbstractViewModel implements ViewModel
     /**
      * Set the data to be rendered in the view - note this does not actually render the view.
      */
-    public function display(array $variables)
+    public function display(array $variables): void
     {
         // Reinstate default variables to ensure they are in expected state when using view in a loop
         $variables = array_merge($this->default_variables, $variables);

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -69,7 +69,7 @@ abstract class AbstractViewModel implements ViewModel
     /**
      * Get field values.
      */
-    public function __get(string $name)
+    public function __get(string $name): mixed
     {
         if (array_key_exists($name, $this->variables)) {
             return $this->variables[$name];
@@ -87,7 +87,7 @@ abstract class AbstractViewModel implements ViewModel
     /**
      * @throws BadMethodCallException values cannot be assigned except with the display method
      */
-    public function __set(string $name, $value)
+    public function __set(string $name, mixed $value)
     {
         throw InvalidViewVarAssignmentException::forReadOnlyVar(static::class, $name);
     }

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -46,7 +46,7 @@ abstract class AbstractViewModel implements ViewModel
     /**
      * @var array Variables that will be set back to defaults on each display unless a new value is passed
      */
-    protected $default_variables = [];
+    protected array $default_variables = [];
 
     /**
      * @var array The actual view data
@@ -56,7 +56,7 @@ abstract class AbstractViewModel implements ViewModel
     /**
      * @var string[] The names of the valid set of fields that must be passed to the display() method
      */
-    protected $expect_var_names = [];
+    protected array $expect_var_names = [];
 
     public function __construct()
     {

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -51,7 +51,7 @@ abstract class AbstractViewModel implements ViewModel
     /**
      * @var array The actual view data
      */
-    protected $variables = [];
+    protected array $variables = [];
 
     /**
      * @var string[] The names of the valid set of fields that must be passed to the display() method

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -68,10 +68,8 @@ abstract class AbstractViewModel implements ViewModel
 
     /**
      * Get field values.
-     *
-     * @param string $name
      */
-    public function __get($name)
+    public function __get(string $name)
     {
         if (array_key_exists($name, $this->variables)) {
             return $this->variables[$name];

--- a/src/ViewModel/NestedChildView.php
+++ b/src/ViewModel/NestedChildView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\ViewModel;
 
 use Ingenerator\KohanaView\ViewModel;

--- a/src/ViewModel/NestedParentView.php
+++ b/src/ViewModel/NestedParentView.php
@@ -7,9 +7,7 @@ use Ingenerator\KohanaView\ViewModel;
 interface NestedParentView extends ViewModel
 {
     /**
-     * @param string $html
-     *
      * @return void
      */
-    public function setBodyHtml($html);
+    public function setBodyHtml(string $html);
 }

--- a/src/ViewModel/NestedParentView.php
+++ b/src/ViewModel/NestedParentView.php
@@ -6,8 +6,5 @@ use Ingenerator\KohanaView\ViewModel;
 
 interface NestedParentView extends ViewModel
 {
-    /**
-     * @return void
-     */
-    public function setBodyHtml(string $html);
+    public function setBodyHtml(string $html): void;
 }

--- a/src/ViewModel/NestedParentView.php
+++ b/src/ViewModel/NestedParentView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\ViewModel;
 
 use Ingenerator\KohanaView\ViewModel;

--- a/src/ViewModel/PageLayout/AbstractIntermediateLayoutView.php
+++ b/src/ViewModel/PageLayout/AbstractIntermediateLayoutView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\NestedParentView;

--- a/src/ViewModel/PageLayout/AbstractIntermediateLayoutView.php
+++ b/src/ViewModel/PageLayout/AbstractIntermediateLayoutView.php
@@ -14,10 +14,7 @@ abstract class AbstractIntermediateLayoutView extends AbstractNestedChildView im
      */
     protected $child_html;
 
-    /**
-     * @param string $html
-     */
-    public function setBodyHtml($html): void
+    public function setBodyHtml(string $html): void
     {
         $this->child_html = $html;
     }

--- a/src/ViewModel/PageLayout/AbstractIntermediateLayoutView.php
+++ b/src/ViewModel/PageLayout/AbstractIntermediateLayoutView.php
@@ -12,7 +12,7 @@ abstract class AbstractIntermediateLayoutView extends AbstractNestedChildView im
     /**
      * @var string set at rendering time by the PageLayoutRenderer
      */
-    protected $child_html;
+    protected string $child_html;
 
     public function setBodyHtml(string $html): void
     {

--- a/src/ViewModel/PageLayout/AbstractIntermediateLayoutView.php
+++ b/src/ViewModel/PageLayout/AbstractIntermediateLayoutView.php
@@ -16,10 +16,8 @@ abstract class AbstractIntermediateLayoutView extends AbstractNestedChildView im
 
     /**
      * @param string $html
-     *
-     * @return void
      */
-    public function setBodyHtml($html)
+    public function setBodyHtml($html): void
     {
         $this->child_html = $html;
     }

--- a/src/ViewModel/PageLayout/AbstractNestedChildView.php
+++ b/src/ViewModel/PageLayout/AbstractNestedChildView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\AbstractViewModel;

--- a/src/ViewModel/PageLayout/AbstractPageContentView.php
+++ b/src/ViewModel/PageLayout/AbstractPageContentView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\NestedParentView;

--- a/src/ViewModel/PageLayout/AbstractPageLayoutView.php
+++ b/src/ViewModel/PageLayout/AbstractPageLayoutView.php
@@ -17,10 +17,7 @@ use Ingenerator\KohanaView\ViewModel\NestedParentView;
  */
 abstract class AbstractPageLayoutView extends AbstractViewModel implements NestedParentView
 {
-    /**
-     * @var array
-     */
-    protected $variables = [
+    protected array $variables = [
         'body_html' => null,
         'title' => null,
     ];

--- a/src/ViewModel/PageLayout/AbstractPageLayoutView.php
+++ b/src/ViewModel/PageLayout/AbstractPageLayoutView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\AbstractViewModel;

--- a/src/ViewModel/PageLayout/AbstractPageLayoutView.php
+++ b/src/ViewModel/PageLayout/AbstractPageLayoutView.php
@@ -25,18 +25,12 @@ abstract class AbstractPageLayoutView extends AbstractViewModel implements Neste
         'title' => null,
     ];
 
-    /**
-     * @param string $title
-     */
-    public function setTitle($title): void
+    public function setTitle(string $title): void
     {
         $this->variables['title'] = $title;
     }
 
-    /**
-     * @param string $html
-     */
-    public function setBodyHTML($html): void
+    public function setBodyHTML(string $html): void
     {
         $this->variables['body_html'] = $html;
     }

--- a/src/ViewModel/PageLayout/AbstractPageLayoutView.php
+++ b/src/ViewModel/PageLayout/AbstractPageLayoutView.php
@@ -27,25 +27,21 @@ abstract class AbstractPageLayoutView extends AbstractViewModel implements Neste
 
     /**
      * @param string $title
-     *
-     * @return void
      */
-    public function setTitle($title)
+    public function setTitle($title): void
     {
         $this->variables['title'] = $title;
     }
 
     /**
      * @param string $html
-     *
-     * @return void
      */
-    public function setBodyHTML($html)
+    public function setBodyHTML($html): void
     {
         $this->variables['body_html'] = $html;
     }
 
-    public function setChildHtml($html)
+    public function setChildHtml($html): void
     {
         $this->variables['body_html'] = $html;
     }

--- a/src/ViewModel/PageLayout/StaticPageContentView.php
+++ b/src/ViewModel/PageLayout/StaticPageContentView.php
@@ -7,7 +7,7 @@ use Ingenerator\KohanaView\TemplateSpecifyingViewModel;
 
 class StaticPageContentView extends AbstractPageContentView implements TemplateSpecifyingViewModel
 {
-    protected $variables = [
+    protected array $variables = [
         'page_path' => null,
     ];
 

--- a/src/ViewModel/PageLayout/StaticPageContentView.php
+++ b/src/ViewModel/PageLayout/StaticPageContentView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\Exception\UnassignedViewVarException;

--- a/src/ViewModel/PageLayout/StaticPageContentView.php
+++ b/src/ViewModel/PageLayout/StaticPageContentView.php
@@ -11,7 +11,7 @@ class StaticPageContentView extends AbstractPageContentView implements TemplateS
         'page_path' => null,
     ];
 
-    public function getTemplateName()
+    public function getTemplateName(): string
     {
         if ( ! $this->variables['page_path']) {
             throw UnassignedViewVarException::forVariable(static::class, 'page_path', 'name/of/view');

--- a/src/ViewTemplateSelector.php
+++ b/src/ViewTemplateSelector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ingenerator\KohanaView;
 
 use Ingenerator\KohanaView\Exception\UnspecifiedTemplateNameException;

--- a/src/ViewTemplateSelector.php
+++ b/src/ViewTemplateSelector.php
@@ -23,10 +23,7 @@ use function strtolower;
  */
 class ViewTemplateSelector
 {
-    /**
-     * @return string
-     */
-    public function getTemplateName(ViewModel $view)
+    public function getTemplateName(ViewModel $view): string
     {
         if ($view instanceof TemplateSpecifyingViewModel) {
             return $this->validateSpecifiedTemplateName($view);

--- a/src/ViewTemplateSelector.php
+++ b/src/ViewTemplateSelector.php
@@ -39,7 +39,7 @@ class ViewTemplateSelector
     {
         $template = $view->getTemplateName();
         $view_class = $view::class;
-        if ( ! $template) {
+        if ($template === '' || $template === '0') {
             throw UnspecifiedTemplateNameException::forEmptyValue($view_class);
         }
 

--- a/src/ViewTemplateSelector.php
+++ b/src/ViewTemplateSelector.php
@@ -5,7 +5,6 @@ namespace Ingenerator\KohanaView;
 use Ingenerator\KohanaView\Exception\UnspecifiedTemplateNameException;
 use UnexpectedValueException;
 
-use function is_string;
 use function preg_replace;
 use function strtolower;
 
@@ -39,12 +38,8 @@ class ViewTemplateSelector
     {
         $template = $view->getTemplateName();
         $view_class = $view::class;
-        if ($template === '' || $template === '0') {
+        if ($template === '') {
             throw UnspecifiedTemplateNameException::forEmptyValue($view_class);
-        }
-
-        if ( ! is_string($template)) {
-            throw UnspecifiedTemplateNameException::forNonStringValue($view_class, $template);
         }
 
         return $template;

--- a/src/ViewTemplateSelector.php
+++ b/src/ViewTemplateSelector.php
@@ -36,11 +36,9 @@ class ViewTemplateSelector
     }
 
     /**
-     * @return string
-     *
      * @throws UnexpectedValueException if no template is provided
      */
-    protected function validateSpecifiedTemplateName(TemplateSpecifyingViewModel $view)
+    protected function validateSpecifiedTemplateName(TemplateSpecifyingViewModel $view): string
     {
         $template = $view->getTemplateName();
         $view_class = $view::class;
@@ -55,10 +53,7 @@ class ViewTemplateSelector
         return $template;
     }
 
-    /**
-     * @return string
-     */
-    protected function calculateTemplateFromClassName(ViewModel $view)
+    protected function calculateTemplateFromClassName(ViewModel $view): string
     {
         $template = $view::class;
         $template = preg_replace('/\\\\|_/', '/', $template);

--- a/src/raw_fn_stub.php
+++ b/src/raw_fn_stub.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This function is never actually called - the template compiler uses it as a marker to render
  * the value directly without escaping it. It is defined here to allow IDE's to cope without marking

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // Bootstrap for running unit tests
 define('TEST_ROOT_PATH', realpath(__DIR__).'/');
 require_once __DIR__.'/../koharness_bootstrap.php';

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -176,7 +176,7 @@ class ViewModelIntegrationTest extends TestCase
         parent::tearDown();
     }
 
-    protected function givenDependenciesBootstrapped()
+    protected function givenDependenciesBootstrapped(): Dependency_Container
     {
         $modules = Kohana::modules();
         $modules['dependencies'] = TEST_ROOT_PATH.'/../vendor/ingenerator/kohana-dependencies';

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -202,10 +202,8 @@ class ViewModelIntegrationTest extends TestCase
     /**
      * @param string $relative_path
      * @param string $content
-     *
-     * @return string
      */
-    protected function givenFileWithContent($relative_path, $content)
+    protected function givenFileWithContent($relative_path, $content): string
     {
         $full_path = $this->tmp_dir.'/'.$relative_path;
 

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -191,10 +191,7 @@ class ViewModelIntegrationTest extends TestCase
         return new Dependency_Container($definitions);
     }
 
-    /**
-     * @return CFSTemplateManager
-     */
-    protected function getTemplateManager(Dependency_Container $dependencies)
+    protected function getTemplateManager(Dependency_Container $dependencies): CFSTemplateManager
     {
         return $dependencies->get('kohanaview.template.manager');
     }
@@ -216,10 +213,7 @@ class ViewModelIntegrationTest extends TestCase
         return $full_path;
     }
 
-    /**
-     * @return HTMLRenderer
-     */
-    protected function getHTMLRenderer(Dependency_Container $dependencies)
+    protected function getHTMLRenderer(Dependency_Container $dependencies): HTMLRenderer
     {
         return $dependencies->get('kohanaview.renderer.html');
     }

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -35,7 +35,7 @@ class ViewModelIntegrationTest extends TestCase
 
     protected $tmp_dir;
 
-    public function test_dependency_container_provides_shared_html_renderer()
+    public function test_dependency_container_provides_shared_html_renderer(): void
     {
         $dependencies = $this->givenDependenciesBootstrapped();
         $renderer = $dependencies->get('kohanaview.renderer.html');
@@ -48,7 +48,7 @@ class ViewModelIntegrationTest extends TestCase
         $this->markTestIncomplete('Cannot put the page layout renderer in the container without defining request');
     }
 
-    public function test_template_manager_cache_dir_defaults_to_inside_kohana_cache_dir()
+    public function test_template_manager_cache_dir_defaults_to_inside_kohana_cache_dir(): void
     {
         $this->givenFileWithContent('module/views/integration/test_view.php', 'Project source template');
         $dependencies = $this->givenDependenciesBootstrapped();
@@ -61,7 +61,7 @@ class ViewModelIntegrationTest extends TestCase
     #[TestWith(['TESTING'])]
     #[TestWith(['STAGING'])]
     #[TestWith(['PRODUCTION'])]
-    public function test_template_compiler_always_compiles_when_no_compiled_template($environment)
+    public function test_template_compiler_always_compiles_when_no_compiled_template($environment): void
     {
         $this->givenFileWithContent('module/views/any_view.php', 'Project source template');
 
@@ -76,7 +76,7 @@ class ViewModelIntegrationTest extends TestCase
     #[TestWith(['TESTING', false])]
     #[TestWith(['STAGING', false])]
     #[TestWith(['PRODUCTION', false])]
-    public function test_template_compiler_recompiles_always_only_in_development($environment, $expect_recompile)
+    public function test_template_compiler_recompiles_always_only_in_development($environment, $expect_recompile): void
     {
         $this->givenFileWithContent('cache/compiled_templates/any_view.php', self::STALE_COMPILED_STRING);
         $this->givenFileWithContent('module/views/any_view.php', 'Project source template');
@@ -94,7 +94,7 @@ class ViewModelIntegrationTest extends TestCase
         }
     }
 
-    public function test_it_renders_expected_view_for_view_model()
+    public function test_it_renders_expected_view_for_view_model(): void
     {
         $this->givenFileWithContent(
             'module/classes/View/Test/SomeModel.php',
@@ -123,7 +123,7 @@ class ViewModelIntegrationTest extends TestCase
         );
     }
 
-    public function test_it_automatically_escapes_view_variables()
+    public function test_it_automatically_escapes_view_variables(): void
     {
         $this->givenFileWithContent(
             'module/classes/View/Test/CustomView.php',

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -61,7 +61,7 @@ class ViewModelIntegrationTest extends TestCase
     #[TestWith(['TESTING'])]
     #[TestWith(['STAGING'])]
     #[TestWith(['PRODUCTION'])]
-    public function test_template_compiler_always_compiles_when_no_compiled_template($environment): void
+    public function test_template_compiler_always_compiles_when_no_compiled_template(string $environment): void
     {
         $this->givenFileWithContent('module/views/any_view.php', 'Project source template');
 
@@ -76,7 +76,7 @@ class ViewModelIntegrationTest extends TestCase
     #[TestWith(['TESTING', false])]
     #[TestWith(['STAGING', false])]
     #[TestWith(['PRODUCTION', false])]
-    public function test_template_compiler_recompiles_always_only_in_development($environment, $expect_recompile): void
+    public function test_template_compiler_recompiles_always_only_in_development(string $environment, $expect_recompile): void
     {
         $this->givenFileWithContent('cache/compiled_templates/any_view.php', self::STALE_COMPILED_STRING);
         $this->givenFileWithContent('module/views/any_view.php', 'Project source template');
@@ -200,10 +200,9 @@ class ViewModelIntegrationTest extends TestCase
     }
 
     /**
-     * @param string $relative_path
      * @param string $content
      */
-    protected function givenFileWithContent($relative_path, $content): string
+    protected function givenFileWithContent(string $relative_path, $content): string
     {
         $full_path = $this->tmp_dir.'/'.$relative_path;
 

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -196,10 +196,7 @@ class ViewModelIntegrationTest extends TestCase
         return $dependencies->get('kohanaview.template.manager');
     }
 
-    /**
-     * @param string $content
-     */
-    protected function givenFileWithContent(string $relative_path, $content): string
+    protected function givenFileWithContent(string $relative_path, string $content): string
     {
         $full_path = $this->tmp_dir.'/'.$relative_path;
 

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\integration;
 
 use Dependency_Container;

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -133,7 +133,7 @@ class ViewModelIntegrationTest extends TestCase
 
                 class CustomView extends \Ingenerator\KohanaView\ViewModel\AbstractViewModel
                 {
-                    protected $variables = [
+                    protected array $variables = [
                         'html_string' => '<p>Stuff&Things</p>'
                     ];
                 }

--- a/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
+++ b/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\mock\CFSWrapper;
 
 use Ingenerator\KohanaView\TemplateManager\CFSWrapper;

--- a/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
+++ b/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
@@ -20,7 +20,7 @@ class SingleDirectoryCFSWrapperMock extends CFSWrapper
     }
 
     #[Override]
-    public function find_file($dir, $file)
+    public function find_file($dir, $file): string|false
     {
         $path = $this->root_path.'/'.$dir.'/'.$file.EXT;
         if (file_exists($path)) {

--- a/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
+++ b/tests/mock/CFSWrapper/SingleDirectoryCFSWrapperMock.php
@@ -12,10 +12,7 @@ use function file_exists;
  */
 class SingleDirectoryCFSWrapperMock extends CFSWrapper
 {
-    /**
-     * @param string $root_path
-     */
-    public function __construct(protected $root_path)
+    public function __construct(protected string $root_path)
     {
     }
 

--- a/tests/mock/ViewModel/FixedTemplateViewModelStub.php
+++ b/tests/mock/ViewModel/FixedTemplateViewModelStub.php
@@ -10,10 +10,7 @@ class FixedTemplateViewModelStub extends ViewModelDummy implements TemplateSpeci
     {
     }
 
-    /**
-     * @return string
-     */
-    public function getTemplateName()
+    public function getTemplateName(): string
     {
         return $this->template;
     }

--- a/tests/mock/ViewModel/FixedTemplateViewModelStub.php
+++ b/tests/mock/ViewModel/FixedTemplateViewModelStub.php
@@ -6,7 +6,7 @@ use Ingenerator\KohanaView\TemplateSpecifyingViewModel;
 
 class FixedTemplateViewModelStub extends ViewModelDummy implements TemplateSpecifyingViewModel
 {
-    public function __construct(private $template)
+    public function __construct(private readonly string $template)
     {
     }
 

--- a/tests/mock/ViewModel/FixedTemplateViewModelStub.php
+++ b/tests/mock/ViewModel/FixedTemplateViewModelStub.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\mock\ViewModel;
 
 use Ingenerator\KohanaView\TemplateSpecifyingViewModel;

--- a/tests/mock/ViewModel/PageLayout/DummyIntermediateLayoutView.php
+++ b/tests/mock/ViewModel/PageLayout/DummyIntermediateLayoutView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\mock\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractIntermediateLayoutView;

--- a/tests/mock/ViewModel/PageLayout/DummyNestedChildView.php
+++ b/tests/mock/ViewModel/PageLayout/DummyNestedChildView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\mock\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractNestedChildView;

--- a/tests/mock/ViewModel/PageLayout/DummyPageContentView.php
+++ b/tests/mock/ViewModel/PageLayout/DummyPageContentView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\mock\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageContentView;

--- a/tests/mock/ViewModel/PageLayout/DummyPageLayoutView.php
+++ b/tests/mock/ViewModel/PageLayout/DummyPageLayoutView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\mock\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageLayoutView;

--- a/tests/mock/ViewModel/ViewModelDummy.php
+++ b/tests/mock/ViewModel/ViewModelDummy.php
@@ -18,10 +18,8 @@ class ViewModelDummy implements ViewModel
      * Create an instance with any arbitrary class name.
      *
      * @param string $class_name
-     *
-     * @return ViewModelDummy
      */
-    public static function make($class_name)
+    public static function make($class_name): self
     {
         if (class_exists($class_name)) {
             $instance = new $class_name();

--- a/tests/mock/ViewModel/ViewModelDummy.php
+++ b/tests/mock/ViewModel/ViewModelDummy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\mock\ViewModel;
 
 use Ingenerator\KohanaView\ViewModel;

--- a/tests/mock/ViewModel/ViewModelDummy.php
+++ b/tests/mock/ViewModel/ViewModelDummy.php
@@ -16,10 +16,8 @@ class ViewModelDummy implements ViewModel
 {
     /**
      * Create an instance with any arbitrary class name.
-     *
-     * @param string $class_name
      */
-    public static function make($class_name): self
+    public static function make(string $class_name): self
     {
         if (class_exists($class_name)) {
             $instance = new $class_name();

--- a/tests/mock/ViewModel/ViewModelDummy.php
+++ b/tests/mock/ViewModel/ViewModelDummy.php
@@ -39,7 +39,7 @@ class ViewModelDummy implements ViewModel
         return new $class_name();
     }
 
-    public function display(array $variables)
+    public function display(array $variables): void
     {
     }
 }

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -213,7 +213,7 @@ class ViewTemplateSelectorSpy extends ViewTemplateSelector
     protected $calls = [];
 
     #[Override]
-    public function getTemplateName(ViewModel $view)
+    public function getTemplateName(ViewModel $view): string
     {
         $this->calls[] = $view;
 

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\Renderer;
 
 use ErrorException;

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -184,7 +184,7 @@ class HTMLRendererTest extends TestCase
         );
     }
 
-    protected function givenTemplate($content)
+    protected function givenTemplate($content): void
     {
         $filename = uniqid('test-template').'.php';
         $file = new vfsStreamFile($filename);

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -224,7 +224,7 @@ class TemplateManagerSpy implements TemplateManager
         $this->template_path = $path;
     }
 
-    public function getPath($template_name)
+    public function getPath($template_name): string
     {
         $this->calls[] = $template_name;
 

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -26,25 +26,13 @@ use function uniqid;
 
 class HTMLRendererTest extends TestCase
 {
-    /**
-     * @var TemplateManagerSpy
-     */
-    protected $template_manager;
+    protected TemplateManagerSpy $template_manager;
 
-    /**
-     * @var ViewTemplateSelectorSpy
-     */
-    protected $template_selector;
+    protected ViewTemplateSelectorSpy $template_selector;
 
-    /**
-     * @var vfsStreamDirectory
-     */
-    protected $vfs_root;
+    protected vfsStreamDirectory $vfs_root;
 
-    /**
-     * @var int
-     */
-    protected $old_error_reporting;
+    protected int $old_error_reporting;
 
     public function test_it_is_initialisable(): void
     {

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -46,27 +46,27 @@ class HTMLRendererTest extends TestCase
      */
     protected $old_error_reporting;
 
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(HTMLRenderer::class, $subject);
         $this->assertInstanceOf(Renderer::class, $subject);
     }
 
-    public function test_it_selects_template_for_view()
+    public function test_it_selects_template_for_view(): void
     {
         $view = new ViewModelDummy();
         $this->newSubject()->render($view);
         $this->template_selector->assertCalledOnceWith($view);
     }
 
-    public function test_it_locates_required_template()
+    public function test_it_locates_required_template(): void
     {
         $this->newSubject()->render(new ViewModelDummy());
         $this->template_manager->assertCalledOnceWith(ViewTemplateSelectorSpy::FIXED_TEMPLATE_NAME);
     }
 
-    public function test_it_returns_template_output_string()
+    public function test_it_returns_template_output_string(): void
     {
         $this->givenTemplate('Any <?="string";?>');
         $this->assertSame(
@@ -75,7 +75,7 @@ class HTMLRendererTest extends TestCase
         );
     }
 
-    public function test_it_provides_view_as_variable_in_template_scope()
+    public function test_it_provides_view_as_variable_in_template_scope(): void
     {
         $this->givenTemplate('View:<?=spl_object_hash($view);?>');
         $view = new ViewModelDummy();
@@ -85,7 +85,7 @@ class HTMLRendererTest extends TestCase
         );
     }
 
-    public function test_it_provides_renderer_as_variable_in_template_scope()
+    public function test_it_provides_renderer_as_variable_in_template_scope(): void
     {
         $this->givenTemplate('Renderer:<?=spl_object_hash($renderer);?>');
         $subject = $this->newSubject();
@@ -95,7 +95,7 @@ class HTMLRendererTest extends TestCase
         );
     }
 
-    public function test_it_does_not_provide_access_to_this_in_template_scope()
+    public function test_it_does_not_provide_access_to_this_in_template_scope(): void
     {
         $this->givenTemplate(
             '<?=isset($this) ? \'Unexpected $this: \'.get_class($this).\':\'.spl_object_hash($this) : \'OK, no $this\';?>'
@@ -106,7 +106,7 @@ class HTMLRendererTest extends TestCase
         );
     }
 
-    public function test_it_does_not_provide_access_to_any_unexpected_variables_in_template_scope()
+    public function test_it_does_not_provide_access_to_any_unexpected_variables_in_template_scope(): void
     {
         $this->givenTemplate(
             '<?=implode("\n", array_keys(get_defined_vars()));?>'
@@ -123,7 +123,7 @@ class HTMLRendererTest extends TestCase
         $this->markTestIncomplete('Appears to be impossible to remove superglobals from template scope');
     }
 
-    public function test_it_suppresses_template_output_and_clears_buffer_on_exception_during_render()
+    public function test_it_suppresses_template_output_and_clears_buffer_on_exception_during_render(): void
     {
         $ob_level_before = ob_get_level();
         $this->expectOutputRegex('/^$/');
@@ -137,7 +137,7 @@ class HTMLRendererTest extends TestCase
         $this->assertSame($ob_level_before, ob_get_level(), 'Expect any internal output buffers to be cleared');
     }
 
-    public function test_it_can_render_same_template_multiple_times_with_same_or_different_views()
+    public function test_it_can_render_same_template_multiple_times_with_same_or_different_views(): void
     {
         $this->givenTemplate('Number<?=$view->number;?>');
         $view_1 = new NumberViewModel();
@@ -154,7 +154,7 @@ class HTMLRendererTest extends TestCase
         $this->assertSame(['Number1', 'Number2', 'Number3'], $output);
     }
 
-    public function test_it_generates_error_if_template_is_not_found()
+    public function test_it_generates_error_if_template_is_not_found(): void
     {
         $this->template_manager->setTemplatePath(vfsStream::url('/path/to/undefined/file'));
 
@@ -164,7 +164,7 @@ class HTMLRendererTest extends TestCase
         $this->newSubject()->render(new ViewModelDummy());
     }
 
-    public function test_it_throws_if_inclusion_fails_even_with_error_reporting_off()
+    public function test_it_throws_if_inclusion_fails_even_with_error_reporting_off(): void
     {
         error_reporting(0);
         $this->template_manager->setTemplatePath(vfsStream::url('/path/to/undefined/file'));
@@ -220,7 +220,7 @@ class ViewTemplateSelectorSpy extends ViewTemplateSelector
         return static::FIXED_TEMPLATE_NAME;
     }
 
-    public function assertCalledOnceWith(ViewModel $view)
+    public function assertCalledOnceWith(ViewModel $view): void
     {
         Assert::assertSame([$view], $this->calls);
     }
@@ -231,7 +231,7 @@ class TemplateManagerSpy implements TemplateManager
     protected $calls = [];
     protected $template_path;
 
-    public function setTemplatePath($path)
+    public function setTemplatePath($path): void
     {
         $this->template_path = $path;
     }
@@ -243,7 +243,7 @@ class TemplateManagerSpy implements TemplateManager
         return $this->template_path;
     }
 
-    public function assertCalledOnceWith($template_name)
+    public function assertCalledOnceWith($template_name): void
     {
         Assert::assertSame([$template_name], $this->calls);
     }

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -188,7 +188,7 @@ class HTMLRendererTest extends TestCase
         error_reporting($this->old_error_reporting);
     }
 
-    protected function newSubject()
+    protected function newSubject(): HTMLRenderer
     {
         return new HTMLRenderer(
             $this->template_selector,

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -239,7 +239,7 @@ class TemplateManagerSpy implements TemplateManager
 
 class NumberViewModel extends AbstractViewModel
 {
-    protected $variables = [
+    protected array $variables = [
         'number' => 0,
     ];
 }

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -182,10 +182,7 @@ class SimpleRendererStub implements Renderer
         }
     }
 
-    /**
-     * @return string
-     */
-    public function render(ViewModel $view)
+    public function render(ViewModel $view): string
     {
         $hash = spl_object_hash($view);
         Assert::assertArrayHasKey(

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -21,15 +21,9 @@ use function spl_object_hash;
 
 class PageLayoutRendererTest extends TestCase
 {
-    /**
-     * @var SimpleRendererStub
-     */
-    protected $renderer;
+    protected SimpleRendererStub $renderer;
 
-    /**
-     * @var Request
-     */
-    protected $request;
+    protected Request $request;
 
     public function test_it_is_initialisable(): void
     {

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -142,7 +142,7 @@ class PageLayoutRendererTest extends TestCase
         $this->renderer = new SimpleRendererStub();
     }
 
-    protected function newSubject()
+    protected function newSubject(): PageLayoutRenderer
     {
         return new PageLayoutRenderer(
             $this->renderer,

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -121,8 +121,8 @@ class PageLayoutRendererTest extends TestCase
 
     #[DataProvider('provider_render_chain')]
     public function test_it_renders_full_chain_if_with_layout_or_only_first_child_if_not(
-        $use_layout,
-        $expect,
+        bool $use_layout,
+        string $expect,
     ): void {
         $page = new DummyPageLayoutView();
         $sidebar_template = new DummyIntermediateLayoutView($page);

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -31,7 +31,7 @@ class PageLayoutRendererTest extends TestCase
      */
     protected $request;
 
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $this->assertInstanceOf(
             PageLayoutRenderer::class,
@@ -44,7 +44,7 @@ class PageLayoutRendererTest extends TestCase
     #[TestWith([null])]
     public function test_it_renders_just_content_for_all_requests_when_use_layout_explicit_false(
         $request,
-    ) {
+    ): void {
         $this->request = $this->stubRequest($request);
 
         $subject = $this->newSubject();
@@ -60,7 +60,7 @@ class PageLayoutRendererTest extends TestCase
     #[TestWith([null])]
     public function test_it_renders_layout_containing_content_for_all_requests_when_use_layout_explicit_true(
         $request,
-    ) {
+    ): void {
         $this->request = $this->stubRequest($request);
         $subject = $this->newSubject();
         $subject->setUseLayout(true);
@@ -70,7 +70,7 @@ class PageLayoutRendererTest extends TestCase
         $this->assertSame("<Layout#B>\n<Content#A/>\n</Layout#B>", $subject->render($content));
     }
 
-    public function test_by_default_it_renders_layout_containing_content_when_no_request()
+    public function test_by_default_it_renders_layout_containing_content_when_no_request(): void
     {
         $this->request = null;
         $content = new DummyPageContentView($layout = new DummyPageLayoutView());
@@ -79,7 +79,7 @@ class PageLayoutRendererTest extends TestCase
         $this->assertSame("<Layout#B>\n<Content#A/>\n</Layout#B>", $subject->render($content));
     }
 
-    public function test_by_default_it_renders_layout_containing_content_when_request_not_ajax()
+    public function test_by_default_it_renders_layout_containing_content_when_request_not_ajax(): void
     {
         $this->request = $this->stubRequest(['is_ajax' => false]);
         $content = new DummyPageContentView($layout = new DummyPageLayoutView());
@@ -88,7 +88,7 @@ class PageLayoutRendererTest extends TestCase
         $this->assertSame("<Layout#B>\n<Content#A/>\n</Layout#B>", $subject->render($content));
     }
 
-    public function test_by_default_it_renders_just_content_when_request_is_ajax()
+    public function test_by_default_it_renders_just_content_when_request_is_ajax(): void
     {
         $this->request = $this->stubRequest(['is_ajax' => true]);
         $content = new DummyPageContentView($layout = new DummyPageLayoutView());
@@ -123,7 +123,7 @@ class PageLayoutRendererTest extends TestCase
     public function test_it_renders_full_chain_if_with_layout_or_only_first_child_if_not(
         $use_layout,
         $expect,
-    ) {
+    ): void {
         $page = new DummyPageLayoutView();
         $sidebar_template = new DummyIntermediateLayoutView($page);
         $second_template = new DummyIntermediateLayoutView($sidebar_template);
@@ -174,7 +174,7 @@ class SimpleRendererStub implements Renderer
 {
     protected $expected_views = [];
 
-    public function registerViews($views)
+    public function registerViews($views): void
     {
         foreach ($views as $key => $view) {
             $hash = spl_object_hash($view);

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -43,7 +43,7 @@ class PageLayoutRendererTest extends TestCase
     #[TestWith([['is_ajax' => false]])]
     #[TestWith([null])]
     public function test_it_renders_just_content_for_all_requests_when_use_layout_explicit_false(
-        $request,
+        ?array $request,
     ): void {
         $this->request = $this->stubRequest($request);
 
@@ -59,7 +59,7 @@ class PageLayoutRendererTest extends TestCase
     #[TestWith([['is_ajax' => false]])]
     #[TestWith([null])]
     public function test_it_renders_layout_containing_content_for_all_requests_when_use_layout_explicit_true(
-        $request,
+        ?array $request,
     ): void {
         $this->request = $this->stubRequest($request);
         $subject = $this->newSubject();

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -99,7 +99,7 @@ class PageLayoutRendererTest extends TestCase
         );
     }
 
-    public static function provider_render_chain()
+    public static function provider_render_chain(): array
     {
         return [
             [

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\Renderer;
 
 use Ingenerator\KohanaView\Renderer;

--- a/tests/unit/Renderer/PageLayoutRendererTest.php
+++ b/tests/unit/Renderer/PageLayoutRendererTest.php
@@ -23,7 +23,7 @@ class PageLayoutRendererTest extends TestCase
 {
     protected SimpleRendererStub $renderer;
 
-    protected Request $request;
+    protected ?Request $request = null;
 
     public function test_it_is_initialisable(): void
     {

--- a/tests/unit/TemplateCompilerTest.php
+++ b/tests/unit/TemplateCompilerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit;
 
 use Ingenerator\KohanaView\Exception\InvalidTemplateContentException;

--- a/tests/unit/TemplateCompilerTest.php
+++ b/tests/unit/TemplateCompilerTest.php
@@ -217,7 +217,7 @@ class TemplateCompilerTest extends TestCase
         $this->assertEquals($expect, $this->newSubject()->compile($source));
     }
 
-    protected function newSubject()
+    protected function newSubject(): TemplateCompiler
     {
         return new TemplateCompiler($this->options);
     }

--- a/tests/unit/TemplateCompilerTest.php
+++ b/tests/unit/TemplateCompilerTest.php
@@ -90,7 +90,7 @@ class TemplateCompilerTest extends TestCase
 ;?>', '<?=HTML::chars($view->anything
 ? \'stuff\'
 : \'\');?>'])]
-    public function test_it_properly_escapes_short_echo_tags_with_ternaries($source, $expect): void
+    public function test_it_properly_escapes_short_echo_tags_with_ternaries(string $source, $expect): void
     {
         $this->assertSame($expect, $this->newSubject()->compile($source));
     }
@@ -99,7 +99,7 @@ class TemplateCompilerTest extends TestCase
     #[TestWith(['<?=raw($foo); //comment?>', '<?php echo($foo); //comment?>'])]
     #[TestWith(['<?=//$foo?>', "<?='';//\$foo;?>"])]
     #[TestWith(['<?=//$foo;?>', "<?='';//\$foo;?>"])]
-    public function test_it_properly_escapes_short_echo_tags_with_comments($source, $expect): void
+    public function test_it_properly_escapes_short_echo_tags_with_comments(string $source, $expect): void
     {
         $this->assertSame($expect, $this->newSubject()->compile($source));
     }
@@ -109,7 +109,7 @@ class TemplateCompilerTest extends TestCase
     #[TestWith(['<?= raw($foo);?>', '<?php echo($foo);?>'])]
     #[TestWith(['<?= raw(HTML::chars($foo));?>', '<?php echo(HTML::chars($foo));?>'])]
     #[TestWith(['<?=raw(do(lots(of(nested(things()))))) ;?>', '<?php echo(do(lots(of(nested(things())))));?>'])]
-    public function test_it_does_not_escape_short_echo_tags_when_marked_as_raw($source, $expect): void
+    public function test_it_does_not_escape_short_echo_tags_when_marked_as_raw(string $source, $expect): void
     {
         $this->assertSame($expect, $this->newSubject()->compile($source));
     }

--- a/tests/unit/TemplateCompilerTest.php
+++ b/tests/unit/TemplateCompilerTest.php
@@ -11,7 +11,7 @@ class TemplateCompilerTest extends TestCase
 {
     protected $options = [];
 
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $this->assertInstanceOf(
             TemplateCompiler::class,
@@ -19,13 +19,13 @@ class TemplateCompilerTest extends TestCase
         );
     }
 
-    public function test_it_throws_if_template_empty()
+    public function test_it_throws_if_template_empty(): void
     {
         $this->expectException(InvalidTemplateContentException::class);
         $this->newSubject()->compile('');
     }
 
-    public function test_it_returns_html_unmodified()
+    public function test_it_returns_html_unmodified(): void
     {
         $html = '<html><head><title></title></head><body><h1>some code</h1></body>';
         $this->assertSame(
@@ -34,7 +34,7 @@ class TemplateCompilerTest extends TestCase
         );
     }
 
-    public function test_it_does_not_modify_php_comments()
+    public function test_it_does_not_modify_php_comments(): void
     {
         $source = <<<PHP
                         <?php
@@ -54,7 +54,7 @@ class TemplateCompilerTest extends TestCase
         );
     }
 
-    public function test_it_does_not_modify_code_in_full_php_tags()
+    public function test_it_does_not_modify_code_in_full_php_tags(): void
     {
         $source = <<<'PHP'
                         <html>
@@ -74,7 +74,7 @@ class TemplateCompilerTest extends TestCase
     #[TestWith(['<?=$view->someMethod();?>', '<?=HTML::chars($view->someMethod());?>'])]
     #[TestWith(['<?=$any_var;?>', '<?=HTML::chars($any_var);?>'])]
     #[TestWith(['<?=$any_var?>', '<?=HTML::chars($any_var);?>'])]
-    public function test_it_automatically_escapes_short_echo_tags_by_default($source, $expect)
+    public function test_it_automatically_escapes_short_echo_tags_by_default($source, $expect): void
     {
         $source = "<p>$source</p>";
         $this->assertSame(
@@ -90,7 +90,7 @@ class TemplateCompilerTest extends TestCase
 ;?>', '<?=HTML::chars($view->anything
 ? \'stuff\'
 : \'\');?>'])]
-    public function test_it_properly_escapes_short_echo_tags_with_ternaries($source, $expect)
+    public function test_it_properly_escapes_short_echo_tags_with_ternaries($source, $expect): void
     {
         $this->assertSame($expect, $this->newSubject()->compile($source));
     }
@@ -99,7 +99,7 @@ class TemplateCompilerTest extends TestCase
     #[TestWith(['<?=raw($foo); //comment?>', '<?php echo($foo); //comment?>'])]
     #[TestWith(['<?=//$foo?>', "<?='';//\$foo;?>"])]
     #[TestWith(['<?=//$foo;?>', "<?='';//\$foo;?>"])]
-    public function test_it_properly_escapes_short_echo_tags_with_comments($source, $expect)
+    public function test_it_properly_escapes_short_echo_tags_with_comments($source, $expect): void
     {
         $this->assertSame($expect, $this->newSubject()->compile($source));
     }
@@ -109,30 +109,30 @@ class TemplateCompilerTest extends TestCase
     #[TestWith(['<?= raw($foo);?>', '<?php echo($foo);?>'])]
     #[TestWith(['<?= raw(HTML::chars($foo));?>', '<?php echo(HTML::chars($foo));?>'])]
     #[TestWith(['<?=raw(do(lots(of(nested(things()))))) ;?>', '<?php echo(do(lots(of(nested(things())))));?>'])]
-    public function test_it_does_not_escape_short_echo_tags_when_marked_as_raw($source, $expect)
+    public function test_it_does_not_escape_short_echo_tags_when_marked_as_raw($source, $expect): void
     {
         $this->assertSame($expect, $this->newSubject()->compile($source));
     }
 
-    public function test_it_throws_if_template_already_escapes_value_in_short_tags()
+    public function test_it_throws_if_template_already_escapes_value_in_short_tags(): void
     {
         $this->expectException(InvalidTemplateContentException::class);
         $this->newSubject()->compile('<?=HTML::chars($double_escape_whoops);?>');
     }
 
-    public function test_it_throws_if_template_uses_old_style_raw_exclamation_mark_prefix()
+    public function test_it_throws_if_template_uses_old_style_raw_exclamation_mark_prefix(): void
     {
         $this->expectException(InvalidTemplateContentException::class);
         $this->newSubject()->compile('<?=!$var;?>');
     }
 
-    public function test_it_throws_if_template_uses_old_style_native_php_echo()
+    public function test_it_throws_if_template_uses_old_style_native_php_echo(): void
     {
         $this->expectException(InvalidTemplateContentException::class);
         $this->newSubject()->compile('<p><?php echo $raw_content;?></p>');
     }
 
-    public function test_its_escape_method_is_configurable()
+    public function test_its_escape_method_is_configurable(): void
     {
         $this->options['escape_method'] = 'MyEscape::thing';
         $this->assertSame(
@@ -143,7 +143,7 @@ class TemplateCompilerTest extends TestCase
         );
     }
 
-    public function test_it_compiles_complex_template()
+    public function test_it_compiles_complex_template(): void
     {
         $source = <<<'PHP'
             <?php
@@ -176,7 +176,7 @@ class TemplateCompilerTest extends TestCase
         $this->assertEquals($expected, $this->newSubject()->compile($source));
     }
 
-    public function test_it_compiles_complex_template_with_multiline_raw_call()
+    public function test_it_compiles_complex_template_with_multiline_raw_call(): void
     {
         $source = <<<'PHP'
             <?php

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -40,7 +40,7 @@ class CFSTemplateManagerTest extends TestCase
      */
     protected $vfs_root;
 
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(
@@ -53,7 +53,7 @@ class CFSTemplateManagerTest extends TestCase
         );
     }
 
-    public function test_it_creates_cache_dir_on_compile_if_it_does_not_exist()
+    public function test_it_creates_cache_dir_on_compile_if_it_does_not_exist(): void
     {
         $this->options['cache_dir'] = vfsStream::url('template/path/to/some/random/directory');
         $this->givenFile('module/views/test.php', 'This is the raw view file');
@@ -61,7 +61,7 @@ class CFSTemplateManagerTest extends TestCase
         $this->assertCompiledToFile($compiled_path);
     }
 
-    public function test_it_throws_if_it_cannot_create_cache_dir()
+    public function test_it_throws_if_it_cannot_create_cache_dir(): void
     {
         $this->options['cache_dir'] = vfsStream::url('template/cache');
         chmod($this->options['cache_dir'], 0o500);
@@ -73,7 +73,7 @@ class CFSTemplateManagerTest extends TestCase
         $this->newSubject()->getPath('any/view');
     }
 
-    public function test_it_throws_if_it_cannot_create_compiled_file()
+    public function test_it_throws_if_it_cannot_create_compiled_file(): void
     {
         $this->options['cache_dir'] = vfsStream::url('template/cache');
         chmod($this->options['cache_dir'], 0o500);
@@ -85,13 +85,13 @@ class CFSTemplateManagerTest extends TestCase
         $this->newSubject()->getPath('anything');
     }
 
-    public function test_it_throws_if_no_source_template_for_uncompiled_template_name()
+    public function test_it_throws_if_no_source_template_for_uncompiled_template_name(): void
     {
         $this->expectException(TemplateNotFoundException::class);
         $this->newSubject()->getPath('some/random/template/file/we/do/not/have');
     }
 
-    public function test_it_compiles_template_to_file_if_not_already_compiled()
+    public function test_it_compiles_template_to_file_if_not_already_compiled(): void
     {
         $this->options['cache_dir'] = vfsStream::url('template/cache');
         $this->givenFile('module/views/any/raw_view.php', 'This is the raw view');
@@ -101,7 +101,7 @@ class CFSTemplateManagerTest extends TestCase
         $this->assertCompiledToFile($compiled_url);
     }
 
-    public function test_it_does_not_recompile_templates_when_disabled()
+    public function test_it_does_not_recompile_templates_when_disabled(): void
     {
         $this->options['cache_dir'] = vfsStream::url('template/cache');
         $this->options['recompile_always'] = false;
@@ -113,7 +113,7 @@ class CFSTemplateManagerTest extends TestCase
         $this->compiler->assertNothingCompiled();
     }
 
-    public function test_it_recompiles_once_per_instance_when_enabled()
+    public function test_it_recompiles_once_per_instance_when_enabled(): void
     {
         $this->options['cache_dir'] = vfsStream::url('template/cache');
         $this->options['recompile_always'] = true;
@@ -129,7 +129,7 @@ class CFSTemplateManagerTest extends TestCase
         $this->compiler->assertCompiledOnce('Raw template content');
     }
 
-    public function test_its_source_template_path_is_configurable()
+    public function test_its_source_template_path_is_configurable(): void
     {
         $this->options['template_dir'] = 'templates';
         $this->givenFile('module/templates/any/template_file.php', 'This is raw view in templates');
@@ -203,12 +203,12 @@ class SpyingTemplateCompiler extends TemplateCompiler
         return static::COMPILED_OUTPUT;
     }
 
-    public function assertCompiledOnce($string)
+    public function assertCompiledOnce($string): void
     {
         Assert::assertEquals([$string], $this->compiled);
     }
 
-    public function assertNothingCompiled()
+    public function assertNothingCompiled(): void
     {
         Assert::assertEmpty($this->compiled);
     }

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -160,10 +160,7 @@ class CFSTemplateManagerTest extends TestCase
         return new CFSTemplateManager($this->compiler, $this->options, $this->cfs_wrapper);
     }
 
-    /**
-     * @param string $compiled_url
-     */
-    protected function assertCompiledToFile($compiled_url)
+    protected function assertCompiledToFile(string $compiled_url)
     {
         $this->assertFileExists($compiled_url, "Compiled file $compiled_url should exist");
         $this->assertSame(SpyingTemplateCompiler::COMPILED_OUTPUT, file_get_contents($compiled_url));

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -151,7 +151,7 @@ class CFSTemplateManagerTest extends TestCase
         return new CFSTemplateManager($this->compiler, $this->options, $this->cfs_wrapper);
     }
 
-    protected function assertCompiledToFile(string $compiled_url)
+    protected function assertCompiledToFile(string $compiled_url): void
     {
         $this->assertFileExists($compiled_url, "Compiled file $compiled_url should exist");
         $this->assertSame(SpyingTemplateCompiler::COMPILED_OUTPUT, file_get_contents($compiled_url));
@@ -162,7 +162,7 @@ class CFSTemplateManagerTest extends TestCase
         );
     }
 
-    protected function givenFile(string $path_to_file, $content)
+    protected function givenFile(string $path_to_file, $content): void
     {
         $file = vfsStream::url('template/'.$path_to_file);
         $path = dirname($file);

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\TemplateManager;
 
 use Ingenerator\KohanaView\Exception\TemplateCacheException;

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -184,7 +184,7 @@ class SpyingTemplateCompiler extends TemplateCompiler
     }
 
     #[Override]
-    public function compile($source): ?string
+    public function compile($source): string
     {
         $this->compiled[] = $source;
 

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -155,7 +155,7 @@ class CFSTemplateManagerTest extends TestCase
         parent::setUp();
     }
 
-    protected function newSubject()
+    protected function newSubject(): CFSTemplateManager
     {
         return new CFSTemplateManager($this->compiler, $this->options, $this->cfs_wrapper);
     }

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -25,20 +25,11 @@ class CFSTemplateManagerTest extends TestCase
 {
     protected $options = [];
 
-    /**
-     * @var SingleDirectoryCFSWrapperMock
-     */
-    protected $cfs_wrapper;
+    protected SingleDirectoryCFSWrapperMock $cfs_wrapper;
 
-    /**
-     * @var SpyingTemplateCompiler
-     */
-    protected $compiler;
+    protected SpyingTemplateCompiler $compiler;
 
-    /**
-     * @var vfsStreamDirectory
-     */
-    protected $vfs_root;
+    protected vfsStreamDirectory $vfs_root;
 
     public function test_it_is_initialisable(): void
     {

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -174,7 +174,7 @@ class CFSTemplateManagerTest extends TestCase
         );
     }
 
-    protected function givenFile($path_to_file, $content)
+    protected function givenFile(string $path_to_file, $content)
     {
         $file = vfsStream::url('template/'.$path_to_file);
         $path = dirname($file);

--- a/tests/unit/TemplateManager/CFSTemplateManagerTest.php
+++ b/tests/unit/TemplateManager/CFSTemplateManagerTest.php
@@ -193,7 +193,7 @@ class SpyingTemplateCompiler extends TemplateCompiler
     }
 
     #[Override]
-    public function compile($source)
+    public function compile($source): ?string
     {
         $this->compiled[] = $source;
 

--- a/tests/unit/ViewModel/AbstractViewModelTest.php
+++ b/tests/unit/ViewModel/AbstractViewModelTest.php
@@ -137,7 +137,7 @@ class AbstractViewModelTest extends TestCase
         $this->assertTrue(true);
     }
 
-    protected function newSubject()
+    protected function newSubject(): TestViewModel
     {
         return new TestViewModel();
     }

--- a/tests/unit/ViewModel/AbstractViewModelTest.php
+++ b/tests/unit/ViewModel/AbstractViewModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\ViewModel;
 
 use Ingenerator\KohanaView\Exception\InvalidDisplayVariablesException;

--- a/tests/unit/ViewModel/AbstractViewModelTest.php
+++ b/tests/unit/ViewModel/AbstractViewModelTest.php
@@ -150,11 +150,11 @@ class AbstractViewModelTest extends TestCase
  */
 class TestViewModel extends AbstractViewModel
 {
-    protected $default_variables = [
+    protected array $default_variables = [
         'some_defaulted_var' => 'default value',
     ];
 
-    protected $variables = [
+    protected array $variables = [
         'some_defined_var' => 'expected value',
     ];
 

--- a/tests/unit/ViewModel/AbstractViewModelTest.php
+++ b/tests/unit/ViewModel/AbstractViewModelTest.php
@@ -158,12 +158,12 @@ class TestViewModel extends AbstractViewModel
         'some_defined_var' => 'expected value',
     ];
 
-    protected function var_some_dynamic_var()
+    protected function var_some_dynamic_var(): string
     {
         return 'expected dynamic';
     }
 
-    protected function var_lazy_calculated_value()
+    protected function var_lazy_calculated_value(): string
     {
         $this->variables['lazy_calculated_value'] = 'cached';
 

--- a/tests/unit/ViewModel/AbstractViewModelTest.php
+++ b/tests/unit/ViewModel/AbstractViewModelTest.php
@@ -11,36 +11,36 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractViewModelTest extends TestCase
 {
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(AbstractViewModel::class, $subject);
         $this->assertInstanceOf(ViewModel::class, $subject);
     }
 
-    public function test_it_provides_magic_read_access_to_defined_variables()
+    public function test_it_provides_magic_read_access_to_defined_variables(): void
     {
         $this->assertEquals('expected value', $this->newSubject()->some_defined_var);
     }
 
-    public function test_it_provides_magic_read_access_to_defined_default_variables()
+    public function test_it_provides_magic_read_access_to_defined_default_variables(): void
     {
         $this->assertEquals('default value', $this->newSubject()->some_defaulted_var);
     }
 
-    public function test_it_provides_magic_read_access_to_protected_var_methods()
+    public function test_it_provides_magic_read_access_to_protected_var_methods(): void
     {
         $this->assertEquals('expected dynamic', $this->newSubject()->some_dynamic_var);
     }
 
-    public function test_it_uses_defined_variables_in_preference_to_defined_methods()
+    public function test_it_uses_defined_variables_in_preference_to_defined_methods(): void
     {
         $subject = $this->newSubject();
         $this->assertEquals('calculated', $subject->lazy_calculated_value);
         $this->assertEquals('cached', $subject->lazy_calculated_value);
     }
 
-    public function test_it_throws_if_attempting_to_read_undefined_property()
+    public function test_it_throws_if_attempting_to_read_undefined_property(): void
     {
         $this->expectException(UndefinedViewVarException::class);
         $this->expectExceptionMessage("TestViewModel does not define a 'some_undefined_var' field");
@@ -48,14 +48,14 @@ class AbstractViewModelTest extends TestCase
         $this->newSubject()->some_undefined_var;
     }
 
-    public function test_it_throws_if_attempting_to_set_any_undefined_externally()
+    public function test_it_throws_if_attempting_to_set_any_undefined_externally(): void
     {
         $this->expectException(InvalidViewVarAssignmentException::class);
         $this->expectExceptionMessage('TestViewModel variables are read-only, cannot assign some_defined_var');
         $this->newSubject()->some_defined_var = 'anything';
     }
 
-    public function test_its_display_method_defines_variables()
+    public function test_its_display_method_defines_variables(): void
     {
         $subject = $this->newSubject();
         $subject->display(
@@ -66,28 +66,28 @@ class AbstractViewModelTest extends TestCase
         $this->assertSame('whatever', $subject->some_defined_var);
     }
 
-    public function test_its_display_method_can_define_null_variables()
+    public function test_its_display_method_can_define_null_variables(): void
     {
         $subject = $this->newSubject();
         $subject->display(['some_defined_var' => null]);
         $this->assertNull($subject->some_defined_var);
     }
 
-    public function test_its_display_method_throws_on_unexpected_values()
+    public function test_its_display_method_throws_on_unexpected_values(): void
     {
         $this->expectException(InvalidDisplayVariablesException::class);
         $this->expectExceptionMessage("'random_var' is not expected");
         $this->newSubject()->display(['some_defined_var' => 'new', 'random_var' => 'anything']);
     }
 
-    public function test_its_display_method_throws_on_missing_values()
+    public function test_its_display_method_throws_on_missing_values(): void
     {
         $this->expectException(InvalidDisplayVariablesException::class);
         $this->expectExceptionMessage("'some_defined_var' is missing");
         $this->newSubject()->display([]);
     }
 
-    public function test_its_display_method_can_override_default_values()
+    public function test_its_display_method_can_override_default_values(): void
     {
         $subject = $this->newSubject();
         $subject->display(
@@ -99,7 +99,7 @@ class AbstractViewModelTest extends TestCase
         $this->assertSame('custom', $subject->some_defaulted_var);
     }
 
-    public function test_its_display_method_reinitialises_default_values_if_not_present()
+    public function test_its_display_method_reinitialises_default_values_if_not_present(): void
     {
         $subject = $this->newSubject();
         $subject->display(
@@ -114,7 +114,7 @@ class AbstractViewModelTest extends TestCase
         $this->assertSame('default value', $subject->some_defaulted_var);
     }
 
-    public function test_its_display_method_throws_if_variables_conflict_with_variable_methods()
+    public function test_its_display_method_throws_if_variables_conflict_with_variable_methods(): void
     {
         $this->expectException(InvalidDisplayVariablesException::class);
         $this->expectExceptionMessage("'some_dynamic_var' conflicts with ::var_some_dynamic_var()");
@@ -126,7 +126,7 @@ class AbstractViewModelTest extends TestCase
         );
     }
 
-    public function test_its_display_method_does_not_require_dynamically_set_variables()
+    public function test_its_display_method_does_not_require_dynamically_set_variables(): void
     {
         $subject = $this->newSubject();
         /** @noinspection PhpUnusedLocalVariableInspection */

--- a/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel\NestedChildView;

--- a/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
@@ -7,7 +7,7 @@ use test\mock\ViewModel\PageLayout\DummyIntermediateLayoutView;
 
 class AbstractIntermediateLayoutViewTest extends AbstractNestedChildViewTest
 {
-    public function test_it_exposes_injected_body_html_as_child_html()
+    public function test_it_exposes_injected_body_html_as_child_html(): void
     {
         $subject = $this->newSubject();
         $subject->setBodyHtml('<p>I am the middle bit of your page</p>');

--- a/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
@@ -2,9 +2,9 @@
 
 namespace test\unit\ViewModel\PageLayout;
 
+use Ingenerator\KohanaView\ViewModel\NestedChildView;
 use Override;
 use test\mock\ViewModel\PageLayout\DummyIntermediateLayoutView;
-use test\mock\ViewModel\PageLayout\DummyNestedChildView;
 
 class AbstractIntermediateLayoutViewTest extends AbstractNestedChildViewTest
 {
@@ -16,7 +16,7 @@ class AbstractIntermediateLayoutViewTest extends AbstractNestedChildViewTest
     }
 
     #[Override]
-    protected function newSubject(): DummyNestedChildView
+    protected function newSubject(): NestedChildView
     {
         return new DummyIntermediateLayoutView($this->parent_view);
     }

--- a/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractIntermediateLayoutViewTest.php
@@ -4,6 +4,7 @@ namespace test\unit\ViewModel\PageLayout;
 
 use Override;
 use test\mock\ViewModel\PageLayout\DummyIntermediateLayoutView;
+use test\mock\ViewModel\PageLayout\DummyNestedChildView;
 
 class AbstractIntermediateLayoutViewTest extends AbstractNestedChildViewTest
 {
@@ -15,7 +16,7 @@ class AbstractIntermediateLayoutViewTest extends AbstractNestedChildViewTest
     }
 
     #[Override]
-    protected function newSubject()
+    protected function newSubject(): DummyNestedChildView
     {
         return new DummyIntermediateLayoutView($this->parent_view);
     }

--- a/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
@@ -64,7 +64,7 @@ class AbstractNestedChildViewTest extends TestCase
         $this->parent_view = new DummyPageLayoutView();
     }
 
-    protected function newSubject()
+    protected function newSubject(): DummyNestedChildView
     {
         return new DummyNestedChildView($this->parent_view);
     }

--- a/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
@@ -33,7 +33,7 @@ class AbstractNestedChildViewTest extends TestCase
         $this->newSubject()->page;
     }
 
-    public static function provider_parent_page()
+    public static function provider_parent_page(): array
     {
         return [
             [

--- a/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
@@ -17,17 +17,17 @@ class AbstractNestedChildViewTest extends TestCase
      */
     protected $parent_view;
 
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $this->assertInstanceOf(NestedChildView::class, $this->newSubject());
     }
 
-    public function test_it_exposes_parent_view_on_new_interface()
+    public function test_it_exposes_parent_view_on_new_interface(): void
     {
         $this->assertSame($this->parent_view, $this->newSubject()->getParentView());
     }
 
-    public function test_it_throws_on_attempt_to_access_page_on_old_interface()
+    public function test_it_throws_on_attempt_to_access_page_on_old_interface(): void
     {
         $this->expectException(BadMethodCallException::class);
         $this->newSubject()->page;
@@ -52,7 +52,7 @@ class AbstractNestedChildViewTest extends TestCase
     }
 
     #[DataProvider('provider_parent_page')]
-    public function test_it_can_provide_ultimate_parent_page_up_the_chain($parent, $expect_page)
+    public function test_it_can_provide_ultimate_parent_page_up_the_chain($parent, $expect_page): void
     {
         $this->parent_view = $parent;
         $this->assertSame($expect_page, $this->newSubject()->getUltimatePageView());

--- a/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\ViewModel\PageLayout;
 
 use BadMethodCallException;

--- a/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
@@ -12,10 +12,7 @@ use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
 
 class AbstractNestedChildViewTest extends TestCase
 {
-    /**
-     * @var DummyPageLayoutView
-     */
-    protected $parent_view;
+    protected DummyPageLayoutView $parent_view;
 
     public function test_it_is_initialisable(): void
     {

--- a/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
@@ -4,6 +4,7 @@ namespace test\unit\ViewModel\PageLayout;
 
 use BadMethodCallException;
 use Ingenerator\KohanaView\ViewModel\NestedChildView;
+use Ingenerator\KohanaView\ViewModel\NestedParentView;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\PageLayout\DummyIntermediateLayoutView;
@@ -12,7 +13,7 @@ use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
 
 class AbstractNestedChildViewTest extends TestCase
 {
-    protected DummyPageLayoutView $parent_view;
+    protected NestedParentView $parent_view;
 
     public function test_it_is_initialisable(): void
     {
@@ -61,7 +62,7 @@ class AbstractNestedChildViewTest extends TestCase
         $this->parent_view = new DummyPageLayoutView();
     }
 
-    protected function newSubject(): DummyNestedChildView
+    protected function newSubject(): NestedChildView
     {
         return new DummyNestedChildView($this->parent_view);
     }

--- a/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractNestedChildViewTest.php
@@ -52,7 +52,7 @@ class AbstractNestedChildViewTest extends TestCase
     }
 
     #[DataProvider('provider_parent_page')]
-    public function test_it_can_provide_ultimate_parent_page_up_the_chain($parent, $expect_page): void
+    public function test_it_can_provide_ultimate_parent_page_up_the_chain(DummyPageLayoutView|DummyIntermediateLayoutView $parent, DummyPageLayoutView $expect_page): void
     {
         $this->parent_view = $parent;
         $this->assertSame($expect_page, $this->newSubject()->getUltimatePageView());

--- a/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
@@ -48,7 +48,7 @@ class AbstractPageContentViewTest extends TestCase
         parent::setUp();
     }
 
-    protected function newSubject()
+    protected function newSubject(): TestableAbstractPageContentView
     {
         return new TestableAbstractPageContentView(
             $this->page_layout

--- a/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
@@ -58,7 +58,7 @@ class AbstractPageContentViewTest extends TestCase
 
 class TestableAbstractPageContentView extends AbstractPageContentView
 {
-    protected $variables = [
+    protected array $variables = [
         'message' => null,
     ];
 }

--- a/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
@@ -12,7 +12,7 @@ class AbstractPageContentViewTest extends TestCase
 {
     protected $page_layout;
 
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(
@@ -29,12 +29,12 @@ class AbstractPageContentViewTest extends TestCase
         );
     }
 
-    public function test_it_exposes_page_as_view_variable()
+    public function test_it_exposes_page_as_view_variable(): void
     {
         $this->assertSame($this->page_layout, $this->newSubject()->page);
     }
 
-    public function test_it_does_not_take_page_as_display_value()
+    public function test_it_does_not_take_page_as_display_value(): void
     {
         $this->newSubject()->display(['message' => 'anything']);
 

--- a/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageContentViewTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel;

--- a/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
@@ -14,7 +14,7 @@ class AbstractPageLayoutViewTest extends TestCase
      */
     protected $body_view;
 
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(
@@ -31,21 +31,21 @@ class AbstractPageLayoutViewTest extends TestCase
         );
     }
 
-    public function test_it_has_body_html_variable_with_setter_access()
+    public function test_it_has_body_html_variable_with_setter_access(): void
     {
         $subject = $this->newSubject();
         $subject->setBodyHTML('Any HTML');
         $this->assertSame('Any HTML', $subject->body_html);
     }
 
-    public function test_it_has_page_title_variable_with_setter_access()
+    public function test_it_has_page_title_variable_with_setter_access(): void
     {
         $subject = $this->newSubject();
         $subject->setTitle('Page title goes here');
         $this->assertSame('Page title goes here', $subject->title);
     }
 
-    public function test_it_supports_assigning_all_variables_with_display()
+    public function test_it_supports_assigning_all_variables_with_display(): void
     {
         $subject = $this->newSubject();
         $subject->display(['body_html' => 'Here is the content', 'title' => 'And the title']);

--- a/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
@@ -53,7 +53,7 @@ class AbstractPageLayoutViewTest extends TestCase
         $this->assertSame('And the title', $subject->title);
     }
 
-    protected function newSubject()
+    protected function newSubject(): TestablePageLayoutView
     {
         return new TestablePageLayoutView();
     }

--- a/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
@@ -9,10 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractPageLayoutViewTest extends TestCase
 {
-    /**
-     * @var ViewModel
-     */
-    protected $body_view;
+    protected ViewModel $body_view;
 
     public function test_it_is_initialisable(): void
     {

--- a/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/AbstractPageLayoutViewTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\ViewModel;

--- a/tests/unit/ViewModel/PageLayout/StaticPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/StaticPageContentViewTest.php
@@ -11,14 +11,14 @@ use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
 
 class StaticPageContentViewTest extends TestCase
 {
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $subject = $this->newSubject();
         $this->assertInstanceOf(StaticPageContentView::class, $subject);
         $this->assertInstanceOf(NestedChildView::class, $subject);
     }
 
-    public function test_it_is_a_template_specifying_view()
+    public function test_it_is_a_template_specifying_view(): void
     {
         $this->assertInstanceOf(
             TemplateSpecifyingViewModel::class,
@@ -26,7 +26,7 @@ class StaticPageContentViewTest extends TestCase
         );
     }
 
-    public function test_it_specifies_template_based_on_page_path()
+    public function test_it_specifies_template_based_on_page_path(): void
     {
         $subject = $this->newSubject();
         $subject->display(['page_path' => 'some/content/page']);
@@ -36,7 +36,7 @@ class StaticPageContentViewTest extends TestCase
         );
     }
 
-    public function test_it_throws_if_page_path_not_set_before_get_template_name()
+    public function test_it_throws_if_page_path_not_set_before_get_template_name(): void
     {
         $this->expectException(UnassignedViewVarException::class);
         $this->newSubject()->getTemplateName();

--- a/tests/unit/ViewModel/PageLayout/StaticPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/StaticPageContentViewTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit\ViewModel\PageLayout;
 
 use Ingenerator\KohanaView\Exception\UnassignedViewVarException;

--- a/tests/unit/ViewModel/PageLayout/StaticPageContentViewTest.php
+++ b/tests/unit/ViewModel/PageLayout/StaticPageContentViewTest.php
@@ -42,7 +42,7 @@ class StaticPageContentViewTest extends TestCase
         $this->newSubject()->getTemplateName();
     }
 
-    protected function newSubject()
+    protected function newSubject(): StaticPageContentView
     {
         return new StaticPageContentView(
             new DummyPageLayoutView()

--- a/tests/unit/ViewTemplateSelectorTest.php
+++ b/tests/unit/ViewTemplateSelectorTest.php
@@ -56,10 +56,7 @@ class ViewTemplateSelectorTest extends TestCase
         $this->newSubject()->getTemplateName(new FixedTemplateViewModelStub(new DateTime()));
     }
 
-    /**
-     * @return ViewTemplateSelector
-     */
-    protected function newSubject()
+    protected function newSubject(): ViewTemplateSelector
     {
         return new ViewTemplateSelector();
     }

--- a/tests/unit/ViewTemplateSelectorTest.php
+++ b/tests/unit/ViewTemplateSelectorTest.php
@@ -2,7 +2,6 @@
 
 namespace test\unit;
 
-use DateTime;
 use Ingenerator\KohanaView\Exception\UnspecifiedTemplateNameException;
 use Ingenerator\KohanaView\ViewTemplateSelector;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -47,13 +46,7 @@ class ViewTemplateSelectorTest extends TestCase
     public function test_it_throws_if_template_specifying_view_does_not_specify_a_template(): void
     {
         $this->expectException(UnspecifiedTemplateNameException::class);
-        $this->newSubject()->getTemplateName(new FixedTemplateViewModelStub(null));
-    }
-
-    public function test_it_throws_if_template_specifying_view_returns_non_string_template_name(): void
-    {
-        $this->expectException(UnspecifiedTemplateNameException::class);
-        $this->newSubject()->getTemplateName(new FixedTemplateViewModelStub(new DateTime()));
+        $this->newSubject()->getTemplateName(new FixedTemplateViewModelStub(''));
     }
 
     protected function newSubject(): ViewTemplateSelector

--- a/tests/unit/ViewTemplateSelectorTest.php
+++ b/tests/unit/ViewTemplateSelectorTest.php
@@ -12,7 +12,7 @@ use test\mock\ViewModel\ViewModelDummy;
 
 class ViewTemplateSelectorTest extends TestCase
 {
-    public function test_it_is_initialisable()
+    public function test_it_is_initialisable(): void
     {
         $this->assertInstanceOf(ViewTemplateSelector::class, $this->newSubject());
     }
@@ -28,7 +28,7 @@ class ViewTemplateSelectorTest extends TestCase
     #[TestWith(['Some\Namespaced\View', 'some/namespaced/view'])]
     #[TestWith(['Some_Underscore_DefaultView', 'some/underscore/default'])]
     #[TestWith(['Some_Underscore_DefaultViewModel', 'some/underscore/default'])]
-    public function test_by_default_it_selects_template_from_view_class_name($class_name, $expect_template)
+    public function test_by_default_it_selects_template_from_view_class_name($class_name, $expect_template): void
     {
         $this->assertSame(
             $expect_template,
@@ -38,19 +38,19 @@ class ViewTemplateSelectorTest extends TestCase
 
     #[TestWith(['some_template'])]
     #[TestWith(['some/nested/template'])]
-    public function test_template_specifying_view_class_can_indicate_which_template_to_use($template)
+    public function test_template_specifying_view_class_can_indicate_which_template_to_use($template): void
     {
         $view = new FixedTemplateViewModelStub($template);
         $this->assertSame($template, $this->newSubject()->getTemplateName($view));
     }
 
-    public function test_it_throws_if_template_specifying_view_does_not_specify_a_template()
+    public function test_it_throws_if_template_specifying_view_does_not_specify_a_template(): void
     {
         $this->expectException(UnspecifiedTemplateNameException::class);
         $this->newSubject()->getTemplateName(new FixedTemplateViewModelStub(null));
     }
 
-    public function test_it_throws_if_template_specifying_view_returns_non_string_template_name()
+    public function test_it_throws_if_template_specifying_view_returns_non_string_template_name(): void
     {
         $this->expectException(UnspecifiedTemplateNameException::class);
         $this->newSubject()->getTemplateName(new FixedTemplateViewModelStub(new DateTime()));

--- a/tests/unit/ViewTemplateSelectorTest.php
+++ b/tests/unit/ViewTemplateSelectorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\unit;
 
 use Ingenerator\KohanaView\Exception\UnspecifiedTemplateNameException;

--- a/tests/unit/ViewTemplateSelectorTest.php
+++ b/tests/unit/ViewTemplateSelectorTest.php
@@ -28,7 +28,7 @@ class ViewTemplateSelectorTest extends TestCase
     #[TestWith(['Some\Namespaced\View', 'some/namespaced/view'])]
     #[TestWith(['Some_Underscore_DefaultView', 'some/underscore/default'])]
     #[TestWith(['Some_Underscore_DefaultViewModel', 'some/underscore/default'])]
-    public function test_by_default_it_selects_template_from_view_class_name($class_name, $expect_template): void
+    public function test_by_default_it_selects_template_from_view_class_name(string $class_name, $expect_template): void
     {
         $this->assertSame(
             $expect_template,

--- a/v5-migration-tool/tests/e2e/EndToEndWithExampleFilesTest.php
+++ b/v5-migration-tool/tests/e2e/EndToEndWithExampleFilesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\e2e;
 
 use PHPUnit\Framework\Attributes\DataProvider;


### PR DESCRIPTION
Adds strict types to all properties, method parameters and return values. Some of these were able to be detected using Rector's inbuilt "safe" type detection rules, others are converted from phpdoc using ingenerator/risky-rector-rules.

As part of this I have added handling for some edge cases where native functions (e.g. file_get_contents) can theoretically return false but the method should be typed as returning string. There are some that still aren't handled which would now produce a TypeError but from how they're used/called we know in production they haven't actually been failing so this can be revisited in a future PR.

This will be squash-merged as a single commit, but kept in git blame as these are functional rather than stylistic changes.