### PR TITLE
feat: Support recursively rendering views in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,8 +430,12 @@ class View_That_Does_Work extends \Ingenerator\KohanaView\ViewModel\AbstractView
 The containing view model should expose a reference to the view model for the partial, which might be passed in as a
 constructor dependency, created by a dynamic variable method, or injected in some other way.
 
-View models don't have any reference to the renderer, so they cannot render the partial directly - instead this should
-happen in the template using the current renderer that is provided as a variable inside the template scope.
+View models don't have any reference to the renderer, so they cannot render the partial directly. Instead, this happens
+when the template is rendered. The simplest way to do this is to simply `<?=$view->child_view;?>` - this will 
+automatically detect that the child_view is a ViewModel instance and render it.
+
+Alternatively, the current `Renderer` is provided as the `$renderer` variable inside the template scope, allowing you
+to call `$renderer->render()` yourself.
 
 For example:
 
@@ -456,7 +460,6 @@ class View_Container extends \Ingenerator\KohanaView\ViewModel\AbstractViewModel
 ```php
 <?php
 //application/views/container.php
-use function Ingenerator\KohanaView\OutputValue\raw;
 /**
  * @var \View_Container                               $view
  * @var \Ingenerator\KohanaView\Renderer\HTMLRenderer $renderer
@@ -464,7 +467,7 @@ use function Ingenerator\KohanaView\OutputValue\raw;
 ?>
 <?php foreach($view->users as $user):?>
   <?php $view->face_widget->display(['user' => $user]);?>
-  <?=raw($renderer->render($view)); // Note rendering unescaped HTML ?>
+  <?=$view->face_widget; // Note the rendered HTML for the partial will not be re-escaped ?>
 <?php endforeach; ?>
 ```
 

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -79,6 +79,10 @@ class HTMLRenderer implements Renderer
             return $value->renderSafeHtml();
         }
 
+        if ($value instanceof ViewModel) {
+            return $this->render($value);
+        }
+
         return HTML::chars($value);
     }
 }

--- a/tests/integration/ViewModelIntegrationTest.php
+++ b/tests/integration/ViewModelIntegrationTest.php
@@ -15,8 +15,11 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use View\Test\CustomView;
+use View\Test\InnerView;
+use View\Test\OuterView;
 use View\Test\SomeModel;
 
+use function assert;
 use function constant;
 use function dirname;
 use function file_get_contents;
@@ -160,6 +163,74 @@ class ViewModelIntegrationTest extends TestCase
         $this->assertSame(
             'View with &lt;p&gt;Stuff&amp;Things&lt;/p&gt;, <p>Stuff&Things</p>',
             $this->getHTMLRenderer($dependencies)->render($view)
+        );
+    }
+
+    public function test_it_recursively_renders_nested_views(): void
+    {
+        $this->givenFileWithContent(
+            'module/classes/View/Test/OuterView.php',
+            <<<'PHP'
+                <?php
+                namespace View\Test;
+
+                class OuterView extends \Ingenerator\KohanaView\ViewModel\AbstractViewModel
+                {
+
+                    public function __construct(
+                        public readonly InnerView $inner_view,
+                        public readonly string $title = 'My title',
+                    )
+                    {
+                    }
+                }
+                PHP
+        );
+
+        $this->givenFileWithContent(
+            'module/views/test/outer.php',
+            <<<'PHP'
+                <h4><?=$view->title;?></h4>
+                <div><?=$view->inner_view;?></div>
+                PHP
+        );
+
+        $this->givenFileWithContent(
+            'module/classes/View/Test/InnerView.php',
+            <<<'PHP'
+                <?php
+                namespace View\Test;
+
+                class InnerView extends \Ingenerator\KohanaView\ViewModel\AbstractViewModel
+                {
+
+                    public function __construct(
+                        public readonly string $foo = 'From the inside',
+                    )
+                    {
+                    }
+                }
+                PHP
+        );
+
+        $this->givenFileWithContent(
+            'module/views/test/inner.php',
+            '<p><?=$view->foo;?></p>'
+        );
+
+        $dependencies = $this->givenDependenciesBootstrapped();
+
+        /** @noinspection PhpUndefinedClassInspection */
+        $inner = new InnerView();
+        /** @noinspection PhpUndefinedClassInspection */
+        $outer = new OuterView($inner);
+        assert($outer instanceof ViewModel);
+        $this->assertSame(
+            <<<'HTML'
+                <h4>My title</h4>
+                <div><p>From the inside</p></div>
+                HTML,
+            $this->getHTMLRenderer($dependencies)->render($outer)
         );
     }
 

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -222,6 +222,22 @@ class HTMLRendererTest extends TestCase
         $this->assertSame($expect, $this->newSubject()->escape($value));
     }
 
+    public function testItEscapesViewModelsByRenderingThem(): void
+    {
+        $inner_view = new class implements ViewModel {
+            public $foo = 'From the inside';
+
+            public function display(array $variables): void
+            {
+            }
+        };
+        $this->givenTemplateForViewClass($inner_view, '<p><?=$view->foo;?></p>');
+        $this->assertSame(
+            '<p>From the inside</p>',
+            $this->newSubject()->escape($inner_view),
+        );
+    }
+
     protected function setUp(): void
     {
         $this->old_error_reporting = error_reporting();

--- a/tests/unit/Renderer/HTMLRendererTest.php
+++ b/tests/unit/Renderer/HTMLRendererTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use test\mock\ViewModel\ViewModelDummy;
+use UnexpectedValueException;
 
 use function error_reporting;
 use function Ingenerator\KohanaView\OutputValue\raw;
@@ -33,7 +34,7 @@ use function uniqid;
 
 class HTMLRendererTest extends TestCase
 {
-    protected TemplateManagerSpy $template_manager;
+    protected TemplateManager $template_manager;
 
     protected ViewTemplateSelectorSpy $template_selector;
 
@@ -51,29 +52,25 @@ class HTMLRendererTest extends TestCase
     public function test_it_selects_template_for_view(): void
     {
         $view = new ViewModelDummy();
+        $this->givenTemplateForViewClass($view, 'Anything');
         $this->newSubject()->render($view);
         $this->template_selector->assertCalledOnceWith($view);
     }
 
-    public function test_it_locates_required_template(): void
-    {
-        $this->newSubject()->render(new ViewModelDummy());
-        $this->template_manager->assertCalledOnceWith(ViewTemplateSelectorSpy::FIXED_TEMPLATE_NAME);
-    }
-
     public function test_it_returns_template_output_string(): void
     {
-        $this->givenTemplate('Any <?="string";?>');
+        $view = new ViewModelDummy();
+        $this->givenTemplateForViewClass($view, 'Any <?="string";?>');
         $this->assertSame(
             'Any string',
-            $this->newSubject()->render(new ViewModelDummy()),
+            $this->newSubject()->render($view),
         );
     }
 
     public function test_it_provides_view_as_variable_in_template_scope(): void
     {
-        $this->givenTemplate('View:<?=spl_object_hash($view);?>');
         $view = new ViewModelDummy();
+        $this->givenTemplateForViewClass($view, 'View:<?=spl_object_hash($view);?>');
         $this->assertSame(
             'View:'.spl_object_hash($view),
             $this->newSubject()->render($view),
@@ -82,33 +79,38 @@ class HTMLRendererTest extends TestCase
 
     public function test_it_provides_renderer_as_variable_in_template_scope(): void
     {
-        $this->givenTemplate('Renderer:<?=spl_object_hash($renderer);?>');
+        $view = new ViewModelDummy();
+        $this->givenTemplateForViewClass($view, 'Renderer:<?=spl_object_hash($renderer);?>');
         $subject = $this->newSubject();
         $this->assertSame(
             'Renderer:'.spl_object_hash($subject),
-            $subject->render(new ViewModelDummy()),
+            $subject->render($view),
         );
     }
 
     public function test_it_does_not_provide_access_to_this_in_template_scope(): void
     {
-        $this->givenTemplate(
+        $view = new ViewModelDummy();
+        $this->givenTemplateForViewClass(
+            $view,
             '<?=isset($this) ? \'Unexpected $this: \'.get_class($this).\':\'.spl_object_hash($this) : \'OK, no $this\';?>',
         );
         $this->assertSame(
             'OK, no $this',
-            $this->newSubject()->render(new ViewModelDummy()),
+            $this->newSubject()->render($view),
         );
     }
 
     public function test_it_does_not_provide_access_to_any_unexpected_variables_in_template_scope(): void
     {
-        $this->givenTemplate(
+        $view = new ViewModelDummy();
+        $this->givenTemplateForViewClass(
+            $view,
             '<?=implode("\n", array_keys(get_defined_vars()));?>',
         );
         $this->assertSame(
             "view\nrenderer\ntemplate",
-            $this->newSubject()->render(new ViewModelDummy()),
+            $this->newSubject()->render($view),
         );
     }
 
@@ -122,9 +124,10 @@ class HTMLRendererTest extends TestCase
     {
         $ob_level_before = ob_get_level();
         $this->expectOutputRegex('/^$/');
-        $this->givenTemplate('Stuff <?="that works";?> then <?php throw new \InvalidArgumentException("dammit");?>');
+        $view = new ViewModelDummy();
+        $this->givenTemplateForViewClass($view, 'Stuff <?="that works";?> then <?php throw new \InvalidArgumentException("dammit");?>');
         try {
-            $this->newSubject()->render(new ViewModelDummy());
+            $this->newSubject()->render($view);
             $this->fail('Expected exception to bubble from the template rendering phase');
         } catch (InvalidArgumentException $e) {
             $this->assertSame('dammit', $e->getMessage(), 'Ensure it is the expected exception');
@@ -134,8 +137,8 @@ class HTMLRendererTest extends TestCase
 
     public function test_it_can_render_same_template_multiple_times_with_same_or_different_views(): void
     {
-        $this->givenTemplate('Number<?=$view->number;?>');
         $view_1 = new NumberViewModel();
+        $this->givenTemplateForViewClass($view_1, 'Number<?=$view->number;?>');
         $view_2 = new NumberViewModel();
         $subject = $this->newSubject();
         $output = [];
@@ -151,22 +154,26 @@ class HTMLRendererTest extends TestCase
 
     public function test_it_generates_error_if_template_is_not_found(): void
     {
-        $this->template_manager->setTemplatePath(vfsStream::url('/path/to/undefined/file'));
+        $view = new ViewModelDummy();
+        $this->template_selector->registerTemplate($view::class, '/path/to/undefined/file');
+        $subject = $this->newSubject();
 
         $this->expectException(ErrorException::class);
         $this->expectExceptionMessage('path/to/undefined/file');
-
-        $this->newSubject()->render(new ViewModelDummy());
+        $subject->render($view);
     }
 
     public function test_it_throws_if_inclusion_fails_even_with_error_reporting_off(): void
     {
+        $view = new ViewModelDummy();
+        $this->template_selector->registerTemplate($view::class, '/path/to/undefined/file');
+        $subject = $this->newSubject();
+
         error_reporting(0);
-        $this->template_manager->setTemplatePath(vfsStream::url('/path/to/undefined/file'));
 
         $this->expectException(TemplateNotFoundException::class);
         $this->expectExceptionMessage('path/to/undefined/file');
-        $this->newSubject()->render(new ViewModelDummy());
+        $subject->render($view);
     }
 
     public static function provider_escape(): iterable
@@ -219,9 +226,18 @@ class HTMLRendererTest extends TestCase
     {
         $this->old_error_reporting = error_reporting();
         $this->template_selector = new ViewTemplateSelectorSpy();
-        $this->template_manager = new TemplateManagerSpy();
         $this->vfs_root = vfsStream::setup('templates');
-        $this->givenTemplate('Default');
+        $this->template_manager = new readonly class($this->vfs_root->url()) implements TemplateManager {
+            public function __construct(
+                private string $base_path)
+            {
+            }
+
+            public function getPath(string $template_name): string
+            {
+                return $this->base_path.'/'.$template_name;
+            }
+        };
     }
 
     protected function tearDown(): void
@@ -237,56 +253,42 @@ class HTMLRendererTest extends TestCase
         );
     }
 
-    protected function givenTemplate($content): void
+    private function givenTemplateForViewClass(ViewModel $view, string $content): void
     {
         $filename = uniqid('test-template').'.php';
+        $this->template_selector->registerTemplate($view::class, $filename);
         $file = new vfsStreamFile($filename);
         $file->setContent($content);
         $this->vfs_root->addChild($file);
-        $this->template_manager->setTemplatePath($file->url());
     }
 }
 
 class ViewTemplateSelectorSpy extends ViewTemplateSelector
 {
-    public const FIXED_TEMPLATE_NAME = 'selected_template';
-
     protected $calls = [];
+
+    private array $template_map = [];
+
+    public function registerTemplate(string $class, string $filename): void
+    {
+        $this->template_map[$class] = $filename;
+    }
 
     #[Override]
     public function getTemplateName(ViewModel $view): string
     {
         $this->calls[] = $view;
+        $template = $this->template_map[$view::class] ?? '';
+        if ($template === '') {
+            throw new UnexpectedValueException('No template mocked for '.$view::class);
+        }
 
-        return static::FIXED_TEMPLATE_NAME;
+        return $template;
     }
 
     public function assertCalledOnceWith(ViewModel $view): void
     {
         Assert::assertSame([$view], $this->calls);
-    }
-}
-
-class TemplateManagerSpy implements TemplateManager
-{
-    protected $calls = [];
-    protected $template_path;
-
-    public function setTemplatePath($path): void
-    {
-        $this->template_path = $path;
-    }
-
-    public function getPath($template_name): string
-    {
-        $this->calls[] = $template_name;
-
-        return $this->template_path;
-    }
-
-    public function assertCalledOnceWith($template_name): void
-    {
-        Assert::assertSame([$template_name], $this->calls);
     }
 }
 


### PR DESCRIPTION
Rather than the current syntax:
  
  `<?=raw($renderer->render($view->child));?>`
   
the new escaping logic allows us to simply do: 
  
  `<?=$view->child;?>`

As well as being cleaner, this now means that in most cases the user's 
own template does not need to know it has a reference to the Renderer as
the renderer calls are handled entirely within the compiled templates.