### PR TITLE
fix: Allow `raw()` to accept null values

### DIFF
--- a/src/OutputValue/UnescapedHtmlSafeString.php
+++ b/src/OutputValue/UnescapedHtmlSafeString.php
@@ -4,16 +4,23 @@ declare(strict_types=1);
 
 namespace Ingenerator\KohanaView\OutputValue;
 
+use Stringable;
+
 /**
  * The string wrapped by this class will be rendered unescaped into the HTML.
  */
-final readonly class UnescapedHtmlSafeString implements UnescapedSafeHtmlContent
+final readonly class UnescapedHtmlSafeString implements UnescapedSafeHtmlContent, Stringable
 {
     public function __construct(public string $content)
     {
     }
 
     public function renderSafeHtml(): string
+    {
+        return $this->content;
+    }
+
+    public function __toString(): string
     {
         return $this->content;
     }

--- a/src/OutputValue/raw_fn.php
+++ b/src/OutputValue/raw_fn.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ingenerator\KohanaView\OutputValue;
 
-function raw(string $value): UnescapedHtmlSafeString
+function raw(?string $value): UnescapedHtmlSafeString
 {
-    return new UnescapedHtmlSafeString($value);
+    return new UnescapedHtmlSafeString($value ?? '');
 }


### PR DESCRIPTION
Otherwise any old view that is using it would need to be reviewed and updated to do a `?? ''` within the viewmodel / template. Simpler to just let it coalesce to empty string within the raw function itself.