### PR TITLE
feat: Drop constructor from AbstractViewModel

### DIFF
--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -54,11 +54,6 @@ abstract class AbstractViewModel implements ViewModel
 {
     private array $cache = [];
 
-    public function __construct()
-    {
-        // @todo remove the constructor when we have a rector to remove the parent::__construct call
-    }
-
     /**
      * Set the data to be rendered in the view - note this does not actually render the view.
      */

--- a/src/ViewModel/PageLayout/AbstractNestedChildView.php
+++ b/src/ViewModel/PageLayout/AbstractNestedChildView.php
@@ -13,7 +13,6 @@ abstract class AbstractNestedChildView extends AbstractViewModel implements Nest
     public function __construct(
         protected NestedParentView $parent_view,
     ) {
-        parent::__construct();
     }
 
     public function getParentView(): NestedParentView

--- a/v5-migration-tool/UPGRADING-to-5.x.md
+++ b/v5-migration-tool/UPGRADING-to-5.x.md
@@ -294,3 +294,10 @@ use function Ingenerator\KohanaView\OutputValue\raw;
 <h1><?=raw($view->label);?> Heading</h1>
 <div><?=$view->content_view;?></div>
 ```
+
+### `AbstractViewModel` no longer has a constructor
+
+Any extending classes will need to remove `parent::__construct()` calls (unless they extend an intermediate class
+that defines a constructor).
+
+The migration tool will attempt to detect and remove these redundant calls.

--- a/v5-migration-tool/kohana-view-v5-migration-set-config.php
+++ b/v5-migration-tool/kohana-view-v5-migration-set-config.php
@@ -8,6 +8,7 @@ use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\KohanaView\ViewModel\PageLayoutView;
 use Ingenerator\KohanaViewV5MigrationTool\Rector\AddKohanaViewReturnTypesRector;
 use Ingenerator\KohanaViewV5MigrationTool\Rector\DisableCustomVarValidationRector;
+use Ingenerator\KohanaViewV5MigrationTool\Rector\DropAbstractViewModelConstructorRector;
 use Ingenerator\KohanaViewV5MigrationTool\Rector\FixPhpDocPropertiesWithoutDollarPrefixRector;
 use Ingenerator\KohanaViewV5MigrationTool\Rector\MigrateComputedPropertiesToAsymmetricVisibilityRector;
 use Ingenerator\KohanaViewV5MigrationTool\Rector\MigrateComputedPropertiesToPropertyHooksRector;
@@ -32,5 +33,6 @@ return static function (RectorConfig $rectorConfig): void {
         DisableCustomVarValidationRector::class,
         AddKohanaViewReturnTypesRector::class,
         UseKohanaViewNewTemplateEscapingRector::class,
+        DropAbstractViewModelConstructorRector::class,
     ]);
 };

--- a/v5-migration-tool/src/Rector/DropAbstractViewModelConstructorRector.php
+++ b/v5-migration-tool/src/Rector/DropAbstractViewModelConstructorRector.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ingenerator\KohanaViewV5MigrationTool\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\Reflection\ClassReflection;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+
+use function assert;
+
+class DropAbstractViewModelConstructorRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ViewModelClassFilter $classFilter,
+        private readonly ReflectionResolver $reflectionResolver,
+    ) {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node)
+    {
+        assert($node instanceof Class_);
+        if ( ! $this->classFilter->isAbstractViewModelClass($node)) {
+            // Not an AbstractViewModel
+            return null;
+        }
+
+        $constructor = $node->getMethod('__construct');
+        if ( ! $constructor instanceof ClassMethod) {
+            // No constructor
+            return null;
+        }
+
+        if ($this->shouldSkipClass($node)) {
+            return null;
+        }
+
+        foreach ($constructor->stmts as $index => $stmt) {
+            if ($this->isParentConstructorCall($stmt)) {
+                unset($constructor->stmts[$index]);
+
+                return $node;
+            }
+        }
+
+        // Nothing removed
+        return null;
+    }
+
+    private function isParentConstructorCall(mixed $stmt): bool
+    {
+        if ( ! $stmt instanceof Expression) {
+            return false;
+        }
+
+        if ( ! $stmt->expr instanceof StaticCall) {
+            return false;
+        }
+
+        return
+            $stmt->expr->class instanceof Name
+            && $stmt->expr->class->toString() === 'parent'
+            && $stmt->expr->name instanceof Identifier
+            && $stmt->expr->name->toString() === '__construct'
+        ;
+    }
+
+    private function shouldSkipClass(Class_ $node): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if ( ! $classReflection instanceof ClassReflection) {
+            // Can't resolve reflection for this class, err on side of safety and abort
+            return true;
+        }
+
+        $parentReflection = $classReflection->getParentClass();
+        while ($parentReflection) {
+            if ($parentReflection->hasMethod('__construct')) {
+                // A parent class does have a constructor so we need to call it
+                return true;
+            }
+            $parentReflection = $parentReflection->getParentClass();
+        }
+
+        // There are no parents with constructors so we can remove any parent call
+        return false;
+    }
+}

--- a/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/DescendantViewWithNeededConstructorCall.expected.php
+++ b/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/DescendantViewWithNeededConstructorCall.expected.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace e2e\examples\src\DropAbstractViewModelConstructor;
+
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+
+class DescendantViewWithNeededConstructorCall extends IntermediateViewWithConstructor
+{
+
+    public function __construct(public readonly MyService $something)
+    {
+        parent::__construct();
+    }
+}
+
+class IntermediateViewWithConstructor extends AbstractViewModel
+{
+
+    protected string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'bar';
+    }
+}

--- a/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/DescendantViewWithNeededConstructorCall.php
+++ b/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/DescendantViewWithNeededConstructorCall.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace e2e\examples\src\DropAbstractViewModelConstructor;
+
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+
+class DescendantViewWithNeededConstructorCall extends IntermediateViewWithConstructor
+{
+
+    public function __construct(public readonly MyService $something)
+    {
+        parent::__construct();
+    }
+}
+
+class IntermediateViewWithConstructor extends AbstractViewModel
+{
+
+    protected string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'bar';
+    }
+}

--- a/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/DescendantViewWithRedundantConstructorCall.expected.php
+++ b/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/DescendantViewWithRedundantConstructorCall.expected.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace e2e\examples\src\DropAbstractViewModelConstructor;
+
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+
+class DescendantViewWithRedundantConstructorCall extends IntermediateView
+{
+
+    public function __construct(public readonly MyService $something)
+    {
+    }
+}
+
+class IntermediateView extends AbstractViewModel
+{
+
+}

--- a/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/DescendantViewWithRedundantConstructorCall.php
+++ b/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/DescendantViewWithRedundantConstructorCall.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace e2e\examples\src\DropAbstractViewModelConstructor;
+
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+
+class DescendantViewWithRedundantConstructorCall extends IntermediateView
+{
+
+    public function __construct(public readonly MyService $something)
+    {
+        parent::__construct();
+    }
+}
+
+class IntermediateView extends AbstractViewModel
+{
+
+}

--- a/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/ViewWithRedundantConstructorCall.expected.php
+++ b/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/ViewWithRedundantConstructorCall.expected.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace e2e\examples\src\DropAbstractViewModelConstructor;
+
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+
+class ViewWithRedundantConstructorCall extends AbstractViewModel
+{
+    private string $foo;
+
+    public function __construct(public readonly MyService $something)
+    {
+        $this->foo = 'bar';
+    }
+}

--- a/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/ViewWithRedundantConstructorCall.php
+++ b/v5-migration-tool/tests/e2e/examples/src/DropAbstractViewModelConstructor/ViewWithRedundantConstructorCall.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace e2e\examples\src\DropAbstractViewModelConstructor;
+
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+
+class ViewWithRedundantConstructorCall extends AbstractViewModel
+{
+    private string $foo;
+
+    public function __construct(public readonly MyService $something)
+    {
+        $this->foo = 'bar';
+        parent::__construct();
+    }
+}


### PR DESCRIPTION
And update the migration tool to remove redundant parent::__construct calls.