### PR TITLE
feat: Refactor parsing display variable schemas & support optional cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 5.0.0-alpha2 (2025-11-04)
+
+* Refactor parsing AbstractViewModel schemas and support optionally caching them in a psr/cache implementation.
+
 ## 5.0.0-alpha (2025-11-03)
 
 * Add a migration tool to assist with upgrading existing projects to 5.x

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ project. Kohana-view doesn't require one in particular, but comes with configura
 using that container, so if you're using something else (really, don't try and do it all inline in PHP) then fetch
 dependencies from your container however required.
 
+### Caching ViewModel schemas
+
+The library needs to parse your AbstractViewModel classes to validate the variables passed to display (see below).
+
+While it will work "out of the box", we strongly recommend registering a suitable psr/cache implementation to avoid any
+performance issues from the use of Reflection at runtime. For example, you could `composer require symfony/cache` and 
+add something like this to your bootstrap:
+
+```php
+// bootstrap.php
+\Ingenerator\KohanaView\ViewModel\DisplaySchema\ViewDisplaySchemaProviderInstance::init(
+    cache: match(Kohana::$environment) {
+        Kohana::DEVELOPMENT => new \Symfony\Component\Cache\Adapter\ArrayAdapter(),
+        default => new \Symfony\Component\Cache\Adapter\ApcuAdapter(),
+    }
+);
+```
+
 Creating your first view
 ------------------------
 

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
     "require": {
         "composer/installers": "^1.12 || ^2.0",
         "php": "~8.4.0",
-        "ingenerator/kohana-core": "^4.9.0"
+        "ingenerator/kohana-core": "^4.9.0",
+        "psr/cache": "^3.0"
     },
     "require-dev": {
         "kohana/koharness": "dev-master",
@@ -57,7 +58,8 @@
         "phpunit/phpunit": "^12.3.15",
         "friendsofphp/php-cs-fixer": "^3.88",
         "rector/rector": "^2.2",
-        "ingenerator/risky-rector-rules": "dev-main@dev"
+        "ingenerator/risky-rector-rules": "dev-main@dev",
+        "symfony/cache": "^7.3"
     },
     "suggest": {
         "ingenerator/kohana-dependencies": "Dependency Injection container for Kohana 3.x"

--- a/src/ViewModel/AbstractViewModel.php
+++ b/src/ViewModel/AbstractViewModel.php
@@ -6,22 +6,13 @@ namespace Ingenerator\KohanaView\ViewModel;
 
 use Closure;
 use Error;
-use Ingenerator\KohanaView\Attribute\DisplayVariableAttribute;
-use Ingenerator\KohanaView\Attribute\InternalDisplayVariable;
-use Ingenerator\KohanaView\Attribute\RequiredDisplayVariable;
 use Ingenerator\KohanaView\Exception\InvalidDisplayVariablesException;
-use Ingenerator\KohanaView\Exception\InvalidViewDefinitionException;
 use Ingenerator\KohanaView\ViewModel;
-use ReflectionAttribute;
-use ReflectionClass;
-use ReflectionProperty;
+use Ingenerator\KohanaView\ViewModel\DisplaySchema\ViewDisplaySchemaProviderInstance;
 
 use function array_diff;
 use function array_key_exists;
 use function array_keys;
-use function assert;
-use function count;
-use function sprintf;
 
 /**
  * The AbstractViewModel can be used as a base for all ViewModels within the system. It supports providing values
@@ -74,16 +65,16 @@ abstract class AbstractViewModel implements ViewModel
 
     private function mergeDefaultsAndValidateVariables(array $variables): array
     {
-        $schema = $this->parseViewVarSchema();
+        $schema = ViewDisplaySchemaProviderInstance::getDisplaySchema(static::class);
 
         // Merge in defaults for any optional properties before validating
-        $variables = [...$schema['defaults'], ...$variables];
+        $variables = [...$schema->defaults, ...$variables];
 
         // Then validate they provided all / only properties that are expected
         $provided_variables = array_keys($variables);
         $errors = array_filter([
-            'unexpected' => array_values(array_diff($provided_variables, $schema['expected_vars'])),
-            'missing' => array_values(array_diff($schema['expected_vars'], $provided_variables)),
+            'unexpected' => array_values(array_diff($provided_variables, $schema->expected_vars)),
+            'missing' => array_values(array_diff($schema->expected_vars, $provided_variables)),
         ]);
 
         if ($errors !== []) {
@@ -91,95 +82,6 @@ abstract class AbstractViewModel implements ViewModel
         }
 
         return $variables;
-    }
-
-    /**
-     * @return array{expected_vars: list<string>, defaults: array{string, mixed}}
-     */
-    private function parseViewVarSchema(): array
-    {
-        // @todo: Support optional caching of this metadata
-        $refl = new ReflectionClass(static::class);
-
-        $schema = [
-            'expected_vars' => [],
-            'defaults' => [],
-        ];
-
-        foreach ($refl->getProperties() as $property) {
-            $attr = $this->getOrDefaultSingleDisplayVariableAttributeForProperty($property);
-            $this->validatePropertyAttributeDefinition($attr, $property);
-
-            if ($attr->canPassToDisplay()) {
-                $schema['expected_vars'][] = $property->getName();
-                if ( ! $attr->mustPassToDisplay()) {
-                    $schema['defaults'][$property->getName()] = $property->getDefaultValue();
-                }
-            }
-        }
-
-        return $schema;
-    }
-
-    private function getOrDefaultSingleDisplayVariableAttributeForProperty(ReflectionProperty $property): DisplayVariableAttribute
-    {
-        // If there is an explicit attribute on the property that always forces the treatment
-        $attributes = $property->getAttributes(DisplayVariableAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
-        if (count($attributes) > 1) {
-            throw new InvalidViewDefinitionException(
-                sprintf(
-                    'Expected only one %s per property but got %s on %s->$%s (%s)',
-                    DisplayVariableAttribute::class,
-                    count($attributes),
-                    static::class,
-                    $property->getName(),
-                    implode(',', array_map(fn (ReflectionAttribute $a): string => $a->getName(), $attributes))
-                )
-            );
-        }
-
-        if ($attributes !== []) {
-            $attr = $attributes[0]->newInstance();
-            assert($attr instanceof DisplayVariableAttribute);
-
-            return $attr;
-        }
-
-        // Without an attribute, guess based on the property definition. Displayable properties are:
-        // - public (at least for get)
-        // - not a dependency that was injected as a constructor promoted property
-        // - not virtual (e.g. with a get hook and no actual backing property).
-        if ($property->isPublic() && ! $property->isPromoted() && ! $property->isVirtual()) {
-            return new RequiredDisplayVariable();
-        }
-
-        // Otherwise, assume this is an internal property that should not be passed to display
-        return new InternalDisplayVariable();
-    }
-
-    private function validatePropertyAttributeDefinition(DisplayVariableAttribute $attr, ReflectionProperty $property): void
-    {
-        if ($attr->mustPassToDisplay() && ! $attr->canPassToDisplay()) {
-            throw new InvalidViewDefinitionException(
-                sprintf(
-                    'Attribute %s marked that property must be provided but can not be provided (on %s:%s)',
-                    $attr::class,
-                    static::class,
-                    $property->getName()
-                )
-            );
-        }
-
-        if ($attr->canPassToDisplay() && ! $attr->mustPassToDisplay() && ! $property->hasDefaultValue()) {
-            throw new InvalidViewDefinitionException(
-                sprintf(
-                    '%s->$%s was tagged as %s, but has no default value',
-                    static::class,
-                    $property->getName(),
-                    $attr::class
-                )
-            );
-        }
     }
 
     protected function getCached(string $key, Closure $getter): mixed

--- a/src/ViewModel/DisplaySchema/CoreDisplaySchemaProvider.php
+++ b/src/ViewModel/DisplaySchema/CoreDisplaySchemaProvider.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ingenerator\KohanaView\ViewModel\DisplaySchema;
+
+use Ingenerator\KohanaView\Attribute\DisplayVariableAttribute;
+use Ingenerator\KohanaView\Attribute\InternalDisplayVariable;
+use Ingenerator\KohanaView\Attribute\RequiredDisplayVariable;
+use Ingenerator\KohanaView\Exception\InvalidViewDefinitionException;
+use Ingenerator\KohanaView\ViewModelDisplaySchemaProvider;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionProperty;
+
+use function assert;
+use function count;
+use function sprintf;
+
+final class CoreDisplaySchemaProvider implements ViewModelDisplaySchemaProvider
+{
+    public function getSchema(string $model_class): ViewModelDisplaySchema
+    {
+        $refl = new ReflectionClass($model_class);
+
+        $schema = [
+            'expected_vars' => [],
+            'defaults' => [],
+        ];
+
+        foreach ($refl->getProperties() as $property) {
+            $attr = $this->getOrDefaultSingleDisplayVariableAttributeForProperty($property);
+            $this->validatePropertyAttributeDefinition($attr, $property);
+
+            if ($attr->canPassToDisplay()) {
+                $schema['expected_vars'][] = $property->getName();
+                if ( ! $attr->mustPassToDisplay()) {
+                    $schema['defaults'][$property->getName()] = $property->getDefaultValue();
+                }
+            }
+        }
+
+        return new ViewModelDisplaySchema(...$schema);
+    }
+
+    private function getOrDefaultSingleDisplayVariableAttributeForProperty(ReflectionProperty $property): DisplayVariableAttribute
+    {
+        // If there is an explicit attribute on the property that always forces the treatment
+        $attributes = $property->getAttributes(DisplayVariableAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
+        if (count($attributes) > 1) {
+            throw new InvalidViewDefinitionException(
+                sprintf(
+                    'Expected only one %s per property but got %s on %s->$%s (%s)',
+                    DisplayVariableAttribute::class,
+                    count($attributes),
+                    $property->getDeclaringClass()->getName(),
+                    $property->getName(),
+                    implode(',', array_map(fn (ReflectionAttribute $a): string => $a->getName(), $attributes)),
+                ),
+            );
+        }
+
+        if ($attributes !== []) {
+            $attr = $attributes[0]->newInstance();
+            assert($attr instanceof DisplayVariableAttribute);
+
+            return $attr;
+        }
+
+        // Without an attribute, guess based on the property definition. Displayable properties are:
+        // - public (at least for get)
+        // - not a dependency that was injected as a constructor promoted property
+        // - not virtual (e.g. with a get hook and no actual backing property).
+        if ($property->isPublic() && ! $property->isPromoted() && ! $property->isVirtual()) {
+            return new RequiredDisplayVariable();
+        }
+
+        // Otherwise, assume this is an internal property that should not be passed to display
+        return new InternalDisplayVariable();
+    }
+
+    private function validatePropertyAttributeDefinition(DisplayVariableAttribute $attr, ReflectionProperty $property): void
+    {
+        if ($attr->mustPassToDisplay() && ! $attr->canPassToDisplay()) {
+            throw new InvalidViewDefinitionException(
+                sprintf(
+                    'Attribute %s marked that property must be provided but can not be provided (on %s:%s)',
+                    $attr::class,
+                    $property->getDeclaringClass()->getName(),
+                    $property->getName(),
+                ),
+            );
+        }
+
+        if ($attr->canPassToDisplay() && ! $attr->mustPassToDisplay() && ! $property->hasDefaultValue()) {
+            throw new InvalidViewDefinitionException(
+                sprintf(
+                    '%s->$%s was tagged as %s, but has no default value',
+                    $property->getDeclaringClass()->getName(),
+                    $property->getName(),
+                    $attr::class,
+                ),
+            );
+        }
+    }
+}

--- a/src/ViewModel/DisplaySchema/ViewDisplaySchemaProviderInstance.php
+++ b/src/ViewModel/DisplaySchema/ViewDisplaySchemaProviderInstance.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ingenerator\KohanaView\ViewModel\DisplaySchema;
+
+use DateInterval;
+use Ingenerator\KohanaView\ViewModelDisplaySchemaProvider;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class ViewDisplaySchemaProviderInstance
+{
+    private static ?ViewModelDisplaySchemaProvider $provider = null;
+    private static ?CacheItemPoolInterface $cache = null;
+    private static ?DateInterval $cache_ttl = null;
+
+    /**
+     * Initialise the global singleton for generating expected ->display() schema for view models.
+     *
+     * If the singleton is not initialised, the generic CoreDisplaySchemaProvider will be used -
+     * however we strongly recommend registering a cache in production environments to avoid
+     * using reflection on every model at runtime.
+     */
+    public static function init(
+        ViewModelDisplaySchemaProvider $provider = new CoreDisplaySchemaProvider(),
+        ?CacheItemPoolInterface $cache = null,
+        ?DateInterval $cache_ttl = null,
+    ): void {
+        self::$provider = $provider;
+        self::$cache = $cache;
+        self::$cache_ttl = $cache_ttl;
+    }
+
+    /**
+     * @internal used for testing, not expected to be used in external code
+     */
+    public static function resetToDefault(): void
+    {
+        self::$provider = null;
+        self::$cache = null;
+        self::$cache_ttl = null;
+    }
+
+    public static function getDisplaySchema(string $model_class): ViewModelDisplaySchema
+    {
+        self::$provider ??= new CoreDisplaySchemaProvider();
+
+        $cached = self::$cache?->getItem('vds.'.hash('sha1', $model_class));
+        if ($cached && $cached->isHit()) {
+            return $cached->get();
+        }
+
+        $result = self::$provider->getSchema($model_class);
+
+        if ($cached instanceof CacheItemInterface) {
+            $cached->set($result);
+            $cached->expiresAfter(self::$cache_ttl);
+            self::$cache->save($cached);
+        }
+
+        return $result;
+    }
+}

--- a/src/ViewModel/DisplaySchema/ViewModelDisplaySchema.php
+++ b/src/ViewModel/DisplaySchema/ViewModelDisplaySchema.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ingenerator\KohanaView\ViewModel\DisplaySchema;
+
+final readonly class ViewModelDisplaySchema
+{
+    public function __construct(
+        /**
+         * @var list<string>
+         */
+        public array $expected_vars,
+        /**
+         * @var array<string, mixed>
+         */
+        public array $defaults,
+    ) {
+    }
+}

--- a/src/ViewModelDisplaySchemaProvider.php
+++ b/src/ViewModelDisplaySchemaProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ingenerator\KohanaView;
+
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+use Ingenerator\KohanaView\ViewModel\DisplaySchema\ViewModelDisplaySchema;
+
+interface ViewModelDisplaySchemaProvider
+{
+    /**
+     * @param class-string<AbstractViewModel> $model_class
+     */
+    public function getSchema(string $model_class): ViewModelDisplaySchema;
+}

--- a/tests/integration/ViewDisplaySchemaProviderInstanceTest.php
+++ b/tests/integration/ViewDisplaySchemaProviderInstanceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace test\integration;
+
+use Ingenerator\KohanaView\Attribute\InternalDisplayVariable;
+use Ingenerator\KohanaView\Attribute\OptionalDisplayVariable;
+use Ingenerator\KohanaView\Attribute\RequiredDisplayVariable;
+use Ingenerator\KohanaView\ViewModel\AbstractViewModel;
+use Ingenerator\KohanaView\ViewModel\DisplaySchema\CoreDisplaySchemaProvider;
+use Ingenerator\KohanaView\ViewModel\DisplaySchema\ViewDisplaySchemaProviderInstance;
+use Ingenerator\KohanaView\ViewModel\DisplaySchema\ViewModelDisplaySchema;
+use Ingenerator\KohanaView\ViewModelDisplaySchemaProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+use function strlen;
+
+class ViewDisplaySchemaProviderInstanceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        ViewDisplaySchemaProviderInstance::resetToDefault();
+    }
+
+    public function test_it_can_compile_schema_without_being_explicitly_initialised(): void
+    {
+        $view = new class extends AbstractViewModel {
+            public protected(set) string $foo;
+            #[InternalDisplayVariable]
+            public readonly string $bar;
+            #[OptionalDisplayVariable]
+            public protected(set) int $number = 1;
+            #[RequiredDisplayVariable]
+            protected string $info;
+        };
+
+        $this->assertEquals(
+            new ViewModelDisplaySchema(
+                expected_vars: ['foo', 'number', 'info'], defaults: ['number' => 1],
+            ),
+            ViewDisplaySchemaProviderInstance::getDisplaySchema($view::class),
+        );
+    }
+
+    public function test_it_can_register_and_compile_with_a_custom_provider(): void
+    {
+        $view = new class extends AbstractViewModel {
+        };
+
+        ViewDisplaySchemaProviderInstance::init(
+            provider: new class implements ViewModelDisplaySchemaProvider {
+                public function getSchema(string $model_class): ViewModelDisplaySchema
+                {
+                    return new ViewModelDisplaySchema(
+                        expected_vars: [$model_class],
+                        defaults: ['two' => 15],
+                    );
+                }
+            },
+        );
+
+        $this->assertEquals(
+            new ViewModelDisplaySchema(
+                expected_vars: [$view::class],
+                defaults: ['two' => 15],
+            ),
+            ViewDisplaySchemaProviderInstance::getDisplaySchema($view::class),
+        );
+    }
+
+    public function test_it_can_cache_schemas_if_a_cache_is_provided(): void
+    {
+        $view_1 = new class extends AbstractViewModel {
+            public protected(set) string $foo;
+        };
+
+        $view_2 = new class extends AbstractViewModel {
+            #[OptionalDisplayVariable]
+            public protected(set) string $bar = 'whatever';
+        };
+
+        $provider = new class implements ViewModelDisplaySchemaProvider {
+            public private(set) array $calls = [];
+
+            public function getSchema(string $model_class): ViewModelDisplaySchema
+            {
+                $this->calls[] = $model_class;
+
+                return new CoreDisplaySchemaProvider()->getSchema($model_class);
+            }
+        };
+
+        $cache = new ArrayAdapter();
+        ViewDisplaySchemaProviderInstance::init(provider: $provider, cache: $cache);
+
+        $this->assertEquals(
+            [
+                new ViewModelDisplaySchema(expected_vars: ['foo'], defaults: []),
+                new ViewModelDisplaySchema(expected_vars: ['bar'], defaults: ['bar' => 'whatever']),
+                [$view_1::class, $view_2::class],
+            ],
+            [
+                ViewDisplaySchemaProviderInstance::getDisplaySchema($view_1::class),
+                ViewDisplaySchemaProviderInstance::getDisplaySchema($view_2::class),
+                $provider->calls,
+            ],
+            'Behaves as expected on empty cache',
+        );
+
+        $this->assertEquals(
+            [
+                new ViewModelDisplaySchema(expected_vars: ['foo'], defaults: []),
+                new ViewModelDisplaySchema(expected_vars: ['bar'], defaults: ['bar' => 'whatever']),
+                [$view_1::class, $view_2::class],
+            ],
+            [
+                ViewDisplaySchemaProviderInstance::getDisplaySchema($view_1::class),
+                ViewDisplaySchemaProviderInstance::getDisplaySchema($view_2::class),
+                $provider->calls,
+            ],
+            'Does not re-compile on cache hit',
+        );
+
+        $cache->clear();
+
+        $this->assertEquals(
+            [
+                new ViewModelDisplaySchema(expected_vars: ['foo'], defaults: []),
+                new ViewModelDisplaySchema(expected_vars: ['bar'], defaults: ['bar' => 'whatever']),
+                [$view_1::class, $view_2::class, $view_1::class, $view_2::class],
+            ],
+            [
+                ViewDisplaySchemaProviderInstance::getDisplaySchema($view_1::class),
+                ViewDisplaySchemaProviderInstance::getDisplaySchema($view_2::class),
+                $provider->calls,
+            ],
+            'Re-compiles on subsequent cache miss',
+        );
+    }
+
+    public function test_its_cached_values_use_psr_compliant_key(): void
+    {
+        $cache = new ArrayAdapter();
+        $view = new class extends AbstractViewModel {
+        };
+        ViewDisplaySchemaProviderInstance::init(cache: $cache);
+        ViewDisplaySchemaProviderInstance::getDisplaySchema($view::class);
+
+        $items = $cache->getValues();
+        $this->assertCount(1, $items, 'Cache should have exactly one item');
+        $key = array_key_first($items);
+        $this->assertMatchesRegularExpression(
+            '/^[A-Za-z0-9_.]{0,64}$/',
+            $key,
+            'Key should match expected psr/cache pattern',
+        );
+        $this->assertGreaterThanOrEqual(
+            40,
+            strlen((string) $key),
+            'Key should be at least 40 chars',
+        );
+    }
+}


### PR DESCRIPTION
Extract the responsibility for parsing an `AbstractViewModel` display variable schema from the `AbstractViewModel` itself, in favour of a global instance of `ViewModelDisplaySchemaProvider`. This allows for custom parsing strategies, if required.

The global `ViewDisplaySchemaProviderInstance` will use the default provider with no caching by default, but can be initialised with a custom provider and/or a caching layer. This is highly recommended for runtime use.